### PR TITLE
[FIX] Cysharp/ObservableCollections#11

### DIFF
--- a/src/ObservableCollections/Internal/CloneCollection.cs
+++ b/src/ObservableCollections/Internal/CloneCollection.cs
@@ -49,7 +49,7 @@ namespace ObservableCollections.Internal
             }
             else
             {
-                var array = ArrayPool<T>.Shared.Rent(count);
+                var array = ArrayPool<T>.Shared.Rent(16);
 
                 var i = 0;
                 foreach (var item in source)
@@ -75,8 +75,8 @@ namespace ObservableCollections.Internal
             if (array.Length == index)
             {
                 ArrayPool<T>.Shared.Return(array, RuntimeHelpersEx.IsReferenceOrContainsReferences<T>());
+                array = ArrayPool<T>.Shared.Rent(index * 2);
             }
-            array = ArrayPool<T>.Shared.Rent(index * 2);
         }
 
         public void Dispose()


### PR DESCRIPTION
- Modified ArrayPool<T>.Shared.Rent(count) to allocate a minimum buffer size of 16, because at this point the value of count is 0, which unintentionally creates an empty array.
- The doubling of the buffer should be done in the branch whose index has reached the end of the buffer, as well as the deallocation.