### PR TITLE
Remove unnecessary processing of ObservableList.Clear 

### DIFF
--- a/src/ObservableCollections/ObservableList.cs
+++ b/src/ObservableCollections/ObservableList.cs
@@ -113,7 +113,6 @@ namespace ObservableCollections
 
         public void Clear()
         {
-            var l = new List<int>();
             lock (SyncRoot)
             {
                 list.Clear();


### PR DESCRIPTION
ObservableList.Clear had unnecessary processing.
please confirm this is correct.

https://github.com/Cysharp/ObservableCollections/blob/0718da8621988a1cfd0bc1ef08d78ab53ecc3431/src/ObservableCollections/ObservableList.cs#L116C13-L116C37