### PR TITLE
Support for firing add event for initial elements

### DIFF
--- a/src/ObservableCollections.Unity/Assets/Plugins/ObservableCollections/Runtime/IObservableCollection.cs
+++ b/src/ObservableCollections.Unity/Assets/Plugins/ObservableCollections/Runtime/IObservableCollection.cs
@@ -28,7 +28,7 @@ namespace ObservableCollections
         event NotifyCollectionChangedEventHandler<T> RoutingCollectionChanged;
         event Action<NotifyCollectionChangedAction> CollectionStateChanged;
 
-        void AttachFilter(ISynchronizedViewFilter<T, TView> filter);
+        void AttachFilter(ISynchronizedViewFilter<T, TView> filter, bool invokeAddEventForInitialElements = false);
         void ResetFilter(Action<T, TView> resetAction);
         INotifyCollectionChangedSynchronizedView<T, TView> WithINotifyCollectionChanged();
     }

--- a/src/ObservableCollections.Unity/Assets/Plugins/ObservableCollections/Runtime/Internal/CloneCollection.cs
+++ b/src/ObservableCollections.Unity/Assets/Plugins/ObservableCollections/Runtime/Internal/CloneCollection.cs
@@ -49,7 +49,7 @@ namespace ObservableCollections.Internal
             }
             else
             {
-                var array = ArrayPool<T>.Shared.Rent(count);
+                var array = ArrayPool<T>.Shared.Rent(16);
 
                 var i = 0;
                 foreach (var item in source)
@@ -75,8 +75,8 @@ namespace ObservableCollections.Internal
             if (array.Length == index)
             {
                 ArrayPool<T>.Shared.Return(array, RuntimeHelpersEx.IsReferenceOrContainsReferences<T>());
+                array = ArrayPool<T>.Shared.Rent(index * 2);
             }
-            array = ArrayPool<T>.Shared.Rent(index * 2);
         }
 
         public void Dispose()

--- a/src/ObservableCollections.Unity/Assets/Plugins/ObservableCollections/Runtime/Internal/FreezedView.cs
+++ b/src/ObservableCollections.Unity/Assets/Plugins/ObservableCollections/Runtime/Internal/FreezedView.cs
@@ -38,14 +38,22 @@ namespace ObservableCollections.Internal
             }
         }
 
-        public void AttachFilter(ISynchronizedViewFilter<T, TView> filter)
+        public void AttachFilter(ISynchronizedViewFilter<T, TView> filter, bool invokeAddEventForCurrentElements = false)
         {
             lock (SyncRoot)
             {
                 this.filter = filter;
-                foreach (var (value, view) in list)
+                for (var i = 0; i < list.Count; i++)
                 {
-                    filter.InvokeOnAttach(value, view);
+                    var (value, view) = list[i];
+                    if (invokeAddEventForCurrentElements)
+                    {
+                        filter.InvokeOnAdd(value, view, NotifyCollectionChangedEventArgs<T>.Add(value, i));
+                    }
+                    else
+                    {
+                        filter.InvokeOnAttach(value, view);
+                    }
                 }
             }
         }
@@ -133,14 +141,22 @@ namespace ObservableCollections.Internal
             }
         }
 
-        public void AttachFilter(ISynchronizedViewFilter<T, TView> filter)
+        public void AttachFilter(ISynchronizedViewFilter<T, TView> filter, bool invokeAddEventForCurrentElements = false)
         {
             lock (SyncRoot)
             {
                 this.filter = filter;
-                foreach (var (value, view) in array)
+                for (var i = 0; i < array.Length; i++)
                 {
-                    filter.InvokeOnAttach(value, view);
+                    var (value, view) = array[i];
+                    if (invokeAddEventForCurrentElements)
+                    {
+                        filter.InvokeOnAdd(value, view, NotifyCollectionChangedEventArgs<T>.Add(value, i));
+                    }
+                    else
+                    {
+                        filter.InvokeOnAttach(value, view);
+                    }
                 }
             }
         }
@@ -178,7 +194,6 @@ namespace ObservableCollections.Internal
 
         public void Dispose()
         {
-
         }
 
         public void Sort(IComparer<T> comparer)

--- a/src/ObservableCollections.Unity/Assets/Plugins/ObservableCollections/Runtime/Internal/NotifyCollectionChangedSynchronizedView.cs
+++ b/src/ObservableCollections.Unity/Assets/Plugins/ObservableCollections/Runtime/Internal/NotifyCollectionChangedSynchronizedView.cs
@@ -55,7 +55,7 @@ namespace ObservableCollections.Internal
             remove { parent.RoutingCollectionChanged -= value; }
         }
 
-        public void AttachFilter(ISynchronizedViewFilter<T, TView> filter) => parent.AttachFilter(filter);
+        public void AttachFilter(ISynchronizedViewFilter<T, TView> filter, bool invokeAddEventForCurrentElements = false) => parent.AttachFilter(filter, invokeAddEventForCurrentElements);
         public void ResetFilter(Action<T, TView> resetAction) => parent.ResetFilter(resetAction);
         public INotifyCollectionChangedSynchronizedView<T, TView> WithINotifyCollectionChanged() => this;
         public void Dispose()

--- a/src/ObservableCollections.Unity/Assets/Plugins/ObservableCollections/Runtime/Internal/SortedView.cs
+++ b/src/ObservableCollections.Unity/Assets/Plugins/ObservableCollections/Runtime/Internal/SortedView.cs
@@ -51,14 +51,21 @@ namespace ObservableCollections.Internal
             }
         }
 
-        public void AttachFilter(ISynchronizedViewFilter<T, TView> filter)
+        public void AttachFilter(ISynchronizedViewFilter<T, TView> filter, bool invokeAddEventForCurrentElements = false)
         {
             lock (SyncRoot)
             {
                 this.filter = filter;
                 foreach (var (_, (value, view)) in dict)
                 {
-                    filter.InvokeOnAttach(value, view);
+                    if (invokeAddEventForCurrentElements)
+                    {
+                        filter.InvokeOnAdd(value, view, NotifyCollectionChangedEventArgs<T>.Add(value, -1));
+                    }
+                    else
+                    {
+                        filter.InvokeOnAttach(value, view);
+                    }
                 }
             }
         }

--- a/src/ObservableCollections.Unity/Assets/Plugins/ObservableCollections/Runtime/Internal/SortedViewViewComparer.cs
+++ b/src/ObservableCollections.Unity/Assets/Plugins/ObservableCollections/Runtime/Internal/SortedViewViewComparer.cs
@@ -55,14 +55,21 @@ namespace ObservableCollections.Internal
             }
         }
 
-        public void AttachFilter(ISynchronizedViewFilter<T, TView> filter)
+        public void AttachFilter(ISynchronizedViewFilter<T, TView> filter, bool invokeAddEventForCurrentElements = false)
         {
             lock (SyncRoot)
             {
                 this.filter = filter;
                 foreach (var (_, (value, view)) in dict)
                 {
-                    filter.InvokeOnAttach(value, view);
+                    if (invokeAddEventForCurrentElements)
+                    {
+                        filter.InvokeOnAdd(value, view, NotifyCollectionChangedEventArgs<T>.Add(value, -1));
+                    }
+                    else
+                    {
+                        filter.InvokeOnAttach(value, view);
+                    }
                 }
             }
         }

--- a/src/ObservableCollections.Unity/Assets/Plugins/ObservableCollections/Runtime/ObservableHashSet.Views.cs
+++ b/src/ObservableCollections.Unity/Assets/Plugins/ObservableCollections/Runtime/ObservableHashSet.Views.cs
@@ -51,14 +51,21 @@ namespace ObservableCollections
                 }
             }
 
-            public void AttachFilter(ISynchronizedViewFilter<T, TView> filter)
+            public void AttachFilter(ISynchronizedViewFilter<T, TView> filter, bool invokeAddEventForCurrentElements = false)
             {
                 lock (SyncRoot)
                 {
                     this.filter = filter;
                     foreach (var (_, (value, view)) in dict)
                     {
-                        filter.InvokeOnAttach(value, view);
+                        if (invokeAddEventForCurrentElements)
+                        {
+                            filter.InvokeOnAdd((value, view), NotifyCollectionChangedEventArgs<T>.Add(value, -1));
+                        }
+                        else
+                        {
+                            filter.InvokeOnAttach(value, view);
+                        }
                     }
                 }
             }

--- a/src/ObservableCollections.Unity/Assets/Plugins/ObservableCollections/Runtime/ObservableQueue.Views.cs
+++ b/src/ObservableCollections.Unity/Assets/Plugins/ObservableCollections/Runtime/ObservableQueue.Views.cs
@@ -53,14 +53,23 @@ namespace ObservableCollections
                 }
             }
 
-            public void AttachFilter(ISynchronizedViewFilter<T, TView> filter)
+            public void AttachFilter(ISynchronizedViewFilter<T, TView> filter, bool invokeAddEventForCurrentElements = false)
             {
                 lock (SyncRoot)
                 {
                     this.filter = filter;
+                    var i = 0;
                     foreach (var (value, view) in queue)
                     {
-                        filter.InvokeOnAttach(value, view);
+                        if (invokeAddEventForCurrentElements)
+                        {
+                            filter.InvokeOnAdd(value, view, NotifyCollectionChangedEventArgs<T>.Add(value, i));
+                        }
+                        else
+                        {
+                            filter.InvokeOnAttach(value, view);
+                        }
+                        i++;
                     }
                 }
             }

--- a/src/ObservableCollections.Unity/Assets/Plugins/ObservableCollections/Runtime/ObservableRingBuffer.Views.cs
+++ b/src/ObservableCollections.Unity/Assets/Plugins/ObservableCollections/Runtime/ObservableRingBuffer.Views.cs
@@ -54,14 +54,22 @@ namespace ObservableCollections
                 }
             }
 
-            public void AttachFilter(ISynchronizedViewFilter<T, TView> filter)
+            public void AttachFilter(ISynchronizedViewFilter<T, TView> filter, bool invokeAddEventForCurrentElements = false)
             {
                 lock (SyncRoot)
                 {
                     this.filter = filter;
-                    foreach (var (value, view) in ringBuffer)
+                    for (var i = 0; i < ringBuffer.Count; i++)
                     {
-                        filter.InvokeOnAttach(value, view);
+                        var (value, view) = ringBuffer[i];
+                        if (invokeAddEventForCurrentElements)
+                        {
+                            filter.InvokeOnAdd(value, view, NotifyCollectionChangedEventArgs<T>.Add(value, i));
+                        }
+                        else
+                        {
+                            filter.InvokeOnAttach(value, view);
+                        }
                     }
                 }
             }

--- a/src/ObservableCollections.Unity/Assets/Plugins/ObservableCollections/Runtime/ObservableStack.Views.cs
+++ b/src/ObservableCollections.Unity/Assets/Plugins/ObservableCollections/Runtime/ObservableStack.Views.cs
@@ -53,14 +53,23 @@ namespace ObservableCollections
                 }
             }
 
-            public void AttachFilter(ISynchronizedViewFilter<T, TView> filter)
+            public void AttachFilter(ISynchronizedViewFilter<T, TView> filter, bool invokeAddEventForCurrentElements = false)
             {
                 lock (SyncRoot)
                 {
                     this.filter = filter;
+                    var i = 0;
                     foreach (var (value, view) in stack)
                     {
-                        filter.InvokeOnAttach(value, view);
+                        if (invokeAddEventForCurrentElements)
+                        {
+                            filter.InvokeOnAdd(value, view, NotifyCollectionChangedEventArgs<T>.Add(value, i));
+                        }
+                        else
+                        {
+                            filter.InvokeOnAttach(value, view);
+                        }
+                        i++;
                     }
                 }
             }

--- a/src/ObservableCollections.Unity/Assets/Plugins/ObservableCollections/Runtime/Shims/Nullables.cs
+++ b/src/ObservableCollections.Unity/Assets/Plugins/ObservableCollections/Runtime/Shims/Nullables.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 
-#if (NETSTANDARD2_0 || NET_STANDARD_2_0 || NET_4_6) && !UNITY_2021_1_OR_NEWER
+#if NETSTANDARD2_0 || NET_STANDARD_2_0 || NET_4_6
 
 namespace System.Diagnostics.CodeAnalysis
 {

--- a/src/ObservableCollections/IObservableCollection.cs
+++ b/src/ObservableCollections/IObservableCollection.cs
@@ -28,7 +28,7 @@ namespace ObservableCollections
         event NotifyCollectionChangedEventHandler<T>? RoutingCollectionChanged;
         event Action<NotifyCollectionChangedAction>? CollectionStateChanged;
 
-        void AttachFilter(ISynchronizedViewFilter<T, TView> filter);
+        void AttachFilter(ISynchronizedViewFilter<T, TView> filter, bool invokeAddEventForInitialElements = false);
         void ResetFilter(Action<T, TView>? resetAction);
         INotifyCollectionChangedSynchronizedView<T, TView> WithINotifyCollectionChanged();
     }

--- a/src/ObservableCollections/Internal/FreezedView.cs
+++ b/src/ObservableCollections/Internal/FreezedView.cs
@@ -38,14 +38,22 @@ namespace ObservableCollections.Internal
             }
         }
 
-        public void AttachFilter(ISynchronizedViewFilter<T, TView> filter)
+        public void AttachFilter(ISynchronizedViewFilter<T, TView> filter, bool invokeAddEventForCurrentElements = false)
         {
             lock (SyncRoot)
             {
                 this.filter = filter;
-                foreach (var (value, view) in list)
+                for (var i = 0; i < list.Count; i++)
                 {
-                    filter.InvokeOnAttach(value, view);
+                    var (value, view) = list[i];
+                    if (invokeAddEventForCurrentElements)
+                    {
+                        filter.InvokeOnAdd(value, view, NotifyCollectionChangedEventArgs<T>.Add(value, i));
+                    }
+                    else
+                    {
+                        filter.InvokeOnAttach(value, view);
+                    }
                 }
             }
         }
@@ -133,14 +141,22 @@ namespace ObservableCollections.Internal
             }
         }
 
-        public void AttachFilter(ISynchronizedViewFilter<T, TView> filter)
+        public void AttachFilter(ISynchronizedViewFilter<T, TView> filter, bool invokeAddEventForCurrentElements = false)
         {
             lock (SyncRoot)
             {
                 this.filter = filter;
-                foreach (var (value, view) in array)
+                for (var i = 0; i < array.Length; i++)
                 {
-                    filter.InvokeOnAttach(value, view);
+                    var (value, view) = array[i];
+                    if (invokeAddEventForCurrentElements)
+                    {
+                        filter.InvokeOnAdd(value, view, NotifyCollectionChangedEventArgs<T>.Add(value, i));
+                    }
+                    else
+                    {
+                        filter.InvokeOnAttach(value, view);
+                    }
                 }
             }
         }
@@ -178,7 +194,6 @@ namespace ObservableCollections.Internal
 
         public void Dispose()
         {
-
         }
 
         public void Sort(IComparer<T> comparer)

--- a/src/ObservableCollections/Internal/NotifyCollectionChangedSynchronizedView.cs
+++ b/src/ObservableCollections/Internal/NotifyCollectionChangedSynchronizedView.cs
@@ -55,7 +55,7 @@ namespace ObservableCollections.Internal
             remove { parent.RoutingCollectionChanged -= value; }
         }
 
-        public void AttachFilter(ISynchronizedViewFilter<T, TView> filter) => parent.AttachFilter(filter);
+        public void AttachFilter(ISynchronizedViewFilter<T, TView> filter, bool invokeAddEventForCurrentElements = false) => parent.AttachFilter(filter, invokeAddEventForCurrentElements);
         public void ResetFilter(Action<T, TView>? resetAction) => parent.ResetFilter(resetAction);
         public INotifyCollectionChangedSynchronizedView<T, TView> WithINotifyCollectionChanged() => this;
         public void Dispose()

--- a/src/ObservableCollections/Internal/SortedView.cs
+++ b/src/ObservableCollections/Internal/SortedView.cs
@@ -51,14 +51,21 @@ namespace ObservableCollections.Internal
             }
         }
 
-        public void AttachFilter(ISynchronizedViewFilter<T, TView> filter)
+        public void AttachFilter(ISynchronizedViewFilter<T, TView> filter, bool invokeAddEventForCurrentElements = false)
         {
             lock (SyncRoot)
             {
                 this.filter = filter;
                 foreach (var (_, (value, view)) in dict)
                 {
-                    filter.InvokeOnAttach(value, view);
+                    if (invokeAddEventForCurrentElements)
+                    {
+                        filter.InvokeOnAdd(value, view, NotifyCollectionChangedEventArgs<T>.Add(value, -1));
+                    }
+                    else
+                    {
+                        filter.InvokeOnAttach(value, view);
+                    }
                 }
             }
         }

--- a/src/ObservableCollections/Internal/SortedViewViewComparer.cs
+++ b/src/ObservableCollections/Internal/SortedViewViewComparer.cs
@@ -55,14 +55,21 @@ namespace ObservableCollections.Internal
             }
         }
 
-        public void AttachFilter(ISynchronizedViewFilter<T, TView> filter)
+        public void AttachFilter(ISynchronizedViewFilter<T, TView> filter, bool invokeAddEventForCurrentElements = false)
         {
             lock (SyncRoot)
             {
                 this.filter = filter;
                 foreach (var (_, (value, view)) in dict)
                 {
-                    filter.InvokeOnAttach(value, view);
+                    if (invokeAddEventForCurrentElements)
+                    {
+                        filter.InvokeOnAdd(value, view, NotifyCollectionChangedEventArgs<T>.Add(value, -1));
+                    }
+                    else
+                    {
+                        filter.InvokeOnAttach(value, view);
+                    }
                 }
             }
         }

--- a/src/ObservableCollections/ObservableHashSet.Views.cs
+++ b/src/ObservableCollections/ObservableHashSet.Views.cs
@@ -51,14 +51,21 @@ namespace ObservableCollections
                 }
             }
 
-            public void AttachFilter(ISynchronizedViewFilter<T, TView> filter)
+            public void AttachFilter(ISynchronizedViewFilter<T, TView> filter, bool invokeAddEventForCurrentElements = false)
             {
                 lock (SyncRoot)
                 {
                     this.filter = filter;
                     foreach (var (_, (value, view)) in dict)
                     {
-                        filter.InvokeOnAttach(value, view);
+                        if (invokeAddEventForCurrentElements)
+                        {
+                            filter.InvokeOnAdd((value, view), NotifyCollectionChangedEventArgs<T>.Add(value, -1));
+                        }
+                        else
+                        {
+                            filter.InvokeOnAttach(value, view);
+                        }
                     }
                 }
             }

--- a/src/ObservableCollections/ObservableQueue.Views.cs
+++ b/src/ObservableCollections/ObservableQueue.Views.cs
@@ -53,14 +53,23 @@ namespace ObservableCollections
                 }
             }
 
-            public void AttachFilter(ISynchronizedViewFilter<T, TView> filter)
+            public void AttachFilter(ISynchronizedViewFilter<T, TView> filter, bool invokeAddEventForCurrentElements = false)
             {
                 lock (SyncRoot)
                 {
                     this.filter = filter;
+                    var i = 0;
                     foreach (var (value, view) in queue)
                     {
-                        filter.InvokeOnAttach(value, view);
+                        if (invokeAddEventForCurrentElements)
+                        {
+                            filter.InvokeOnAdd(value, view, NotifyCollectionChangedEventArgs<T>.Add(value, i));
+                        }
+                        else
+                        {
+                            filter.InvokeOnAttach(value, view);
+                        }
+                        i++;
                     }
                 }
             }

--- a/src/ObservableCollections/ObservableRingBuffer.Views.cs
+++ b/src/ObservableCollections/ObservableRingBuffer.Views.cs
@@ -54,14 +54,22 @@ namespace ObservableCollections
                 }
             }
 
-            public void AttachFilter(ISynchronizedViewFilter<T, TView> filter)
+            public void AttachFilter(ISynchronizedViewFilter<T, TView> filter, bool invokeAddEventForCurrentElements = false)
             {
                 lock (SyncRoot)
                 {
                     this.filter = filter;
-                    foreach (var (value, view) in ringBuffer)
+                    for (var i = 0; i < ringBuffer.Count; i++)
                     {
-                        filter.InvokeOnAttach(value, view);
+                        var (value, view) = ringBuffer[i];
+                        if (invokeAddEventForCurrentElements)
+                        {
+                            filter.InvokeOnAdd(value, view, NotifyCollectionChangedEventArgs<T>.Add(value, i));
+                        }
+                        else
+                        {
+                            filter.InvokeOnAttach(value, view);
+                        }
                     }
                 }
             }

--- a/src/ObservableCollections/ObservableStack.Views.cs
+++ b/src/ObservableCollections/ObservableStack.Views.cs
@@ -53,14 +53,23 @@ namespace ObservableCollections
                 }
             }
 
-            public void AttachFilter(ISynchronizedViewFilter<T, TView> filter)
+            public void AttachFilter(ISynchronizedViewFilter<T, TView> filter, bool invokeAddEventForCurrentElements = false)
             {
                 lock (SyncRoot)
                 {
                     this.filter = filter;
+                    var i = 0;
                     foreach (var (value, view) in stack)
                     {
-                        filter.InvokeOnAttach(value, view);
+                        if (invokeAddEventForCurrentElements)
+                        {
+                            filter.InvokeOnAdd(value, view, NotifyCollectionChangedEventArgs<T>.Add(value, i));
+                        }
+                        else
+                        {
+                            filter.InvokeOnAttach(value, view);
+                        }
+                        i++;
                     }
                 }
             }

--- a/tests/ObservableCollections.Tests/ObservableDictionaryTest.cs
+++ b/tests/ObservableCollections.Tests/ObservableDictionaryTest.cs
@@ -154,5 +154,36 @@ namespace ObservableCollections.Tests
                 .OrderBy(x => x.Value)
                 .Should().Equal((ChangedKind.Remove, -1090), (ChangedKind.Remove, -100), (ChangedKind.Remove, -53), (ChangedKind.Remove, -40), (ChangedKind.Remove, -34));
         }
+        
+        [Fact]
+        public void FilterAndInvokeAddEvent()
+        {
+            var dict = new ObservableDictionary<int, int>();
+            var view1 = dict.CreateView(x => new ViewContainer<int>(x.Value));
+            var filter1 = new TestFilter2<int>((x, v) => x.Value % 2 == 0);
+
+            dict.Add(10, -12); // 0
+            dict.Add(50, -53); // 1
+            dict.Add(30, -34); // 2
+            dict.Add(20, -25); // 3
+            dict.Add(40, -40); // 4
+            
+            view1.AttachFilter(filter1, true);
+
+            filter1.CalledOnCollectionChanged.Count.Should().Be(5);
+            filter1.CalledOnCollectionChanged[0].changedKind.Should().Be(ChangedKind.Add);
+            filter1.CalledOnCollectionChanged[0].value.Key.Should().Be(10);
+            filter1.CalledOnCollectionChanged[1].changedKind.Should().Be(ChangedKind.Add);
+            filter1.CalledOnCollectionChanged[1].value.Key.Should().Be(50);
+            filter1.CalledOnCollectionChanged[2].changedKind.Should().Be(ChangedKind.Add);
+            filter1.CalledOnCollectionChanged[2].value.Key.Should().Be(30);
+            filter1.CalledOnCollectionChanged[3].changedKind.Should().Be(ChangedKind.Add);
+            filter1.CalledOnCollectionChanged[3].value.Key.Should().Be(20);
+            filter1.CalledOnCollectionChanged[4].changedKind.Should().Be(ChangedKind.Add);
+            filter1.CalledOnCollectionChanged[4].value.Key.Should().Be(40);
+
+            filter1.CalledWhenTrue.Count.Should().Be(3);
+            filter1.CalledWhenFalse.Count.Should().Be(2);
+        }   
     }
 }

--- a/tests/ObservableCollections.Tests/ObservableHashSetTest.cs
+++ b/tests/ObservableCollections.Tests/ObservableHashSetTest.cs
@@ -76,5 +76,35 @@ namespace ObservableCollections.Tests
             set.RemoveRange(new[] { 50, 30 });
             filter.CalledOnCollectionChanged.Select(x => (x.changedKind, x.value)).Should().Equal((ChangedKind.Remove, 10), (ChangedKind.Remove, 50), (ChangedKind.Remove, 30));
         }
+        
+        [Fact]
+        public void FilterAndInvokeAddEvent()
+        {
+            var set = new ObservableHashSet<int>();
+            var view = set.CreateView(x => new ViewContainer<int>(x));
+            var filter = new TestFilter<int>((x, v) => x % 3 == 0);
+
+            set.Add(10);
+            set.Add(50);
+            set.Add(30);
+            set.Add(20);
+            set.Add(40);
+
+            view.AttachFilter(filter, true);
+            filter.CalledOnCollectionChanged.Count.Should().Be(5);
+            filter.CalledOnCollectionChanged[0].changedKind.Should().Be(ChangedKind.Add);
+            filter.CalledOnCollectionChanged[0].value.Should().Be(10);
+            filter.CalledOnCollectionChanged[1].changedKind.Should().Be(ChangedKind.Add);
+            filter.CalledOnCollectionChanged[1].value.Should().Be(50);
+            filter.CalledOnCollectionChanged[2].changedKind.Should().Be(ChangedKind.Add);
+            filter.CalledOnCollectionChanged[2].value.Should().Be(30);
+            filter.CalledOnCollectionChanged[3].changedKind.Should().Be(ChangedKind.Add);
+            filter.CalledOnCollectionChanged[3].value.Should().Be(20);
+            filter.CalledOnCollectionChanged[4].changedKind.Should().Be(ChangedKind.Add);
+            filter.CalledOnCollectionChanged[4].value.Should().Be(40);
+
+            filter.CalledWhenTrue.Count.Should().Be(1);
+            filter.CalledWhenFalse.Count.Should().Be(4);
+        }   
     }
 }

--- a/tests/ObservableCollections.Tests/ObservableListTest.cs
+++ b/tests/ObservableCollections.Tests/ObservableListTest.cs
@@ -218,5 +218,28 @@ namespace ObservableCollections.Tests
             filter2.CalledOnCollectionChanged.Select(x => (x.changedKind, x.value)).Should().Equal((ChangedKind.Remove, 21), (ChangedKind.Remove, 30), (ChangedKind.Remove, 44), (ChangedKind.Remove, 45), (ChangedKind.Remove, 66), (ChangedKind.Remove, 90), (ChangedKind.Remove, 100), (ChangedKind.Remove, 101), (ChangedKind.Remove, 9999));
             filter3.CalledOnCollectionChanged.Select(x => (x.changedKind, x.value)).Should().Equal((ChangedKind.Remove, 21), (ChangedKind.Remove, 30), (ChangedKind.Remove, 44), (ChangedKind.Remove, 45), (ChangedKind.Remove, 66), (ChangedKind.Remove, 90), (ChangedKind.Remove, 100), (ChangedKind.Remove, 101), (ChangedKind.Remove, 9999));
         }
+
+        [Fact]
+        public void FilterAndInvokeAddEvent()
+        {
+            var list = new ObservableList<int>();
+            var view1 = list.CreateView(x => new ViewContainer<int>(x));
+            list.AddRange(new[] { 10, 21, 30, 44 });
+
+            var filter1 = new TestFilter<int>((x, v) => x % 2 == 0);
+            view1.AttachFilter(filter1, true);
+            
+            filter1.CalledOnCollectionChanged[0].changedKind.Should().Be(ChangedKind.Add);
+            filter1.CalledOnCollectionChanged[0].value.Should().Be(10);
+            filter1.CalledOnCollectionChanged[1].changedKind.Should().Be(ChangedKind.Add);
+            filter1.CalledOnCollectionChanged[1].value.Should().Be(21);
+            filter1.CalledOnCollectionChanged[2].changedKind.Should().Be(ChangedKind.Add);
+            filter1.CalledOnCollectionChanged[2].value.Should().Be(30);
+            filter1.CalledOnCollectionChanged[3].changedKind.Should().Be(ChangedKind.Add);
+            filter1.CalledOnCollectionChanged[3].value.Should().Be(44);
+
+            filter1.CalledWhenTrue.Count.Should().Be(3);
+            filter1.CalledWhenFalse.Count.Should().Be(1);
+        }   
     }
 }

--- a/tests/ObservableCollections.Tests/ObservableQueueTest.cs
+++ b/tests/ObservableCollections.Tests/ObservableQueueTest.cs
@@ -80,5 +80,36 @@ namespace ObservableCollections.Tests
             queue.DequeueRange(2);
             filter.CalledOnCollectionChanged.Select(x => (x.changedKind, x.value)).Should().Equal((ChangedKind.Remove, 10), (ChangedKind.Remove, 50), (ChangedKind.Remove, 30));
         }
+        
+        [Fact]
+        public void FilterAndInvokeAddEvent()
+        {
+            var queue = new ObservableQueue<int>();
+            var view = queue.CreateView(x => new ViewContainer<int>(x));
+            var filter = new TestFilter<int>((x, v) => x % 3 == 0);
+
+            queue.Enqueue(10);
+            queue.Enqueue(50);
+            queue.Enqueue(30);
+            queue.Enqueue(20);
+            queue.Enqueue(40);
+
+            view.AttachFilter(filter, true);
+            
+            filter.CalledOnCollectionChanged.Count.Should().Be(5);
+            filter.CalledOnCollectionChanged[0].changedKind.Should().Be(ChangedKind.Add);
+            filter.CalledOnCollectionChanged[0].value.Should().Be(10);
+            filter.CalledOnCollectionChanged[1].changedKind.Should().Be(ChangedKind.Add);
+            filter.CalledOnCollectionChanged[1].value.Should().Be(50);
+            filter.CalledOnCollectionChanged[2].changedKind.Should().Be(ChangedKind.Add);
+            filter.CalledOnCollectionChanged[2].value.Should().Be(30);
+            filter.CalledOnCollectionChanged[3].changedKind.Should().Be(ChangedKind.Add);
+            filter.CalledOnCollectionChanged[3].value.Should().Be(20);
+            filter.CalledOnCollectionChanged[4].changedKind.Should().Be(ChangedKind.Add);
+            filter.CalledOnCollectionChanged[4].value.Should().Be(40);
+
+            filter.CalledWhenTrue.Count.Should().Be(1);
+            filter.CalledWhenFalse.Count.Should().Be(4);
+        }   
     }
 }

--- a/tests/ObservableCollections.Tests/ObservableStackTest.cs
+++ b/tests/ObservableCollections.Tests/ObservableStackTest.cs
@@ -80,5 +80,36 @@ namespace ObservableCollections.Tests
             stack.PopRange(2);
             filter.CalledOnCollectionChanged.Select(x => (x.changedKind, x.value)).Should().Equal((ChangedKind.Remove, 98), (ChangedKind.Remove, 33), (ChangedKind.Remove, 40));
         }
+        
+        [Fact]
+        public void FilterAndInvokeAddEvent()
+        {
+            var stack = new ObservableStack<int>();
+            var view = stack.CreateView(x => new ViewContainer<int>(x));
+            var filter = new TestFilter<int>((x, v) => x % 3 == 0);
+
+            stack.Push(10);
+            stack.Push(50);
+            stack.Push(30);
+            stack.Push(20);
+            stack.Push(40);
+
+            view.AttachFilter(filter, true);
+            filter.CalledOnCollectionChanged.Count.Should().Be(5);
+            filter.CalledOnCollectionChanged[4].changedKind.Should().Be(ChangedKind.Add);
+            filter.CalledOnCollectionChanged[4].value.Should().Be(10);
+            filter.CalledOnCollectionChanged[3].changedKind.Should().Be(ChangedKind.Add);
+            filter.CalledOnCollectionChanged[3].value.Should().Be(50);
+            filter.CalledOnCollectionChanged[2].changedKind.Should().Be(ChangedKind.Add);
+            filter.CalledOnCollectionChanged[2].value.Should().Be(30);
+            filter.CalledOnCollectionChanged[1].changedKind.Should().Be(ChangedKind.Add);
+            filter.CalledOnCollectionChanged[1].value.Should().Be(20);
+            filter.CalledOnCollectionChanged[0].changedKind.Should().Be(ChangedKind.Add);
+            filter.CalledOnCollectionChanged[0].value.Should().Be(40);
+
+            filter.CalledWhenTrue.Count.Should().Be(1);
+            filter.CalledWhenFalse.Count.Should().Be(4);
+        }   
+        
     }
 }


### PR DESCRIPTION
When an AttachFilter is executed, CollectionChangeEvent will not fire for elements that already exist.
(WhenTrue/WhenFalse will fire)

If you are performing some destructive operation on a View (GameObject, etc.) with a CollectionChangeEvent, it may be bad if you cannot apply the same process to an already existing element.

So I added the following overload:
- `AttachFilter<>(filter,  bool invokeAddEventForInitialElements = false)`

( It may not be a very pretty solution..)