### PR TITLE
ObservableList Replace Bugfix

### DIFF
--- a/src/ObservableCollections/ObservableList.Views.cs
+++ b/src/ObservableCollections/ObservableList.Views.cs
@@ -212,7 +212,7 @@ namespace ObservableCollections
                             // ObservableList does not support replace range
                         {
                             var v = (e.NewItem, selector(e.NewItem));
-                            var ov = (e.OldItem, selector(e.OldItem));
+                            var ov = (e.OldItem, list[e.OldStartingIndex].Item2);
                             list[e.NewStartingIndex] = v;
                             filter.InvokeOnReplace(v, ov, e.NewStartingIndex);
                             break;


### PR DESCRIPTION
When replacing, the callback function should refer to the item in the array, rather than generating a new one.