### PR TITLE
ci: change upload-artifact & download-artifact to Cysharp/Actions

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -24,7 +24,7 @@ jobs:
       - run: dotnet test -c Release --no-build
       - run: dotnet pack -c Release --no-build -p:Version=${{ inputs.tag }} -o ./publish
       # Store artifacts.
-      - uses: actions/upload-artifact@v2
+      - uses: Cysharp/Actions/.github/actions/upload-artifact@main
         with:
           name: nuget
           path: ./publish/

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           name: nuget
           path: ./publish/
+          retention-days: 1
 
   # release
   create-release:


### PR DESCRIPTION
## tl;dr;

To handle actions/upload-artifact & download-artifact version consistency, manage actions version via Central Maanged Cysharp/Actions.
