### PR TITLE
fix CloneCollection

### DIFF
--- a/src/ObservableCollections/Internal/CloneCollection.cs
+++ b/src/ObservableCollections/Internal/CloneCollection.cs
@@ -74,8 +74,10 @@ namespace ObservableCollections.Internal
         {
             if (array.Length == index)
             {
+                var newArray = ArrayPool<T>.Shared.Rent(index * 2);
+                Array.Copy(array, newArray, index);
                 ArrayPool<T>.Shared.Return(array, RuntimeHelpersEx.IsReferenceOrContainsReferences<T>());
-                array = ArrayPool<T>.Shared.Rent(index * 2);
+                array = newArray;
             }
         }
 


### PR DESCRIPTION
I think it's the same bug as [#38](https://github.com/Cysharp/ObservableCollections/issues/38#issue-2267065856), In some cases, values were not added correctly when executing `ObvervableList.AddRange`.
```csharp
static IEnumerable<int> Range(int count)
{
    foreach (var x in Enumerable.Range(0, count))
    {
        yield return x;
    }
}

var list = new ObservableList<int>();
list.AddRange(Range(20));
```
The cause is that when `CloneCollection<T>.TryEnsureCapacity` is executed, the items from the old array are not copied to the new array.
Therefore, I have modified the old array items to be copied to the new array as well.