### PR TITLE
Simplify reverse iteration in GetEnumerator()

### DIFF
--- a/src/ObservableCollections/Internal/FreezedView.cs
+++ b/src/ObservableCollections/Internal/FreezedView.cs
@@ -82,24 +82,11 @@ namespace ObservableCollections.Internal
         {
             lock (SyncRoot)
             {
-                if (!reverse)
+                foreach (var item in reverse ? list.AsEnumerable().Reverse() : list)
                 {
-                    foreach (var item in list)
+                    if (filter.IsMatch(item.Item1, item.Item2))
                     {
-                        if (filter.IsMatch(item.Item1, item.Item2))
-                        {
-                            yield return item;
-                        }
-                    }
-                }
-                else
-                {
-                    foreach (var item in list.AsEnumerable().Reverse())
-                    {
-                        if (filter.IsMatch(item.Item1, item.Item2))
-                        {
-                            yield return item;
-                        }
+                        yield return item;
                     }
                 }
             }

--- a/src/ObservableCollections/ObservableList.Views.cs
+++ b/src/ObservableCollections/ObservableList.Views.cs
@@ -108,24 +108,11 @@ namespace ObservableCollections
             {
                 lock (SyncRoot)
                 {
-                    if (!reverse)
+                    foreach (var item in reverse ? list.AsEnumerable().Reverse() : list)
                     {
-                        foreach (var item in list)
+                        if (filter.IsMatch(item.Item1, item.Item2))
                         {
-                            if (filter.IsMatch(item.Item1, item.Item2))
-                            {
-                                yield return item;
-                            }
-                        }
-                    }
-                    else
-                    {
-                        foreach (var item in list.AsEnumerable().Reverse())
-                        {
-                            if (filter.IsMatch(item.Item1, item.Item2))
-                            {
-                                yield return item;
-                            }
+                            yield return item;
                         }
                     }
                 }

--- a/src/ObservableCollections/ObservableQueue.Views.cs
+++ b/src/ObservableCollections/ObservableQueue.Views.cs
@@ -105,24 +105,11 @@ namespace ObservableCollections
             {
                 lock (SyncRoot)
                 {
-                    if (!reverse)
+                    foreach (var item in reverse ? queue.AsEnumerable().Reverse() : queue)
                     {
-                        foreach (var item in queue)
+                        if (filter.IsMatch(item.Item1, item.Item2))
                         {
-                            if (filter.IsMatch(item.Item1, item.Item2))
-                            {
-                                yield return item;
-                            }
-                        }
-                    }
-                    else
-                    {
-                        foreach (var item in queue.AsEnumerable().Reverse())
-                        {
-                            if (filter.IsMatch(item.Item1, item.Item2))
-                            {
-                                yield return item;
-                            }
+                            yield return item;
                         }
                     }
                 }

--- a/src/ObservableCollections/ObservableRingBuffer.Views.cs
+++ b/src/ObservableCollections/ObservableRingBuffer.Views.cs
@@ -106,24 +106,11 @@ namespace ObservableCollections
             {
                 lock (SyncRoot)
                 {
-                    if (!reverse)
+                    foreach (var item in reverse ? ringBuffer.AsEnumerable().Reverse() : ringBuffer)
                     {
-                        foreach (var item in ringBuffer)
+                        if (filter.IsMatch(item.Item1, item.Item2))
                         {
-                            if (filter.IsMatch(item.Item1, item.Item2))
-                            {
-                                yield return item;
-                            }
-                        }
-                    }
-                    else
-                    {
-                        foreach (var item in ringBuffer.AsEnumerable().Reverse())
-                        {
-                            if (filter.IsMatch(item.Item1, item.Item2))
-                            {
-                                yield return item;
-                            }
+                            yield return item;
                         }
                     }
                 }

--- a/src/ObservableCollections/ObservableStack.Views.cs
+++ b/src/ObservableCollections/ObservableStack.Views.cs
@@ -104,24 +104,11 @@ namespace ObservableCollections
             {
                 lock (SyncRoot)
                 {
-                    if (!reverse)
+                    foreach (var item in reverse ? stack.AsEnumerable().Reverse() : stack)
                     {
-                        foreach (var item in stack)
+                        if (filter.IsMatch(item.Item1, item.Item2))
                         {
-                            if (filter.IsMatch(item.Item1, item.Item2))
-                            {
-                                yield return item;
-                            }
-                        }
-                    }
-                    else
-                    {
-                        foreach (var item in stack.AsEnumerable().Reverse())
-                        {
-                            if (filter.IsMatch(item.Item1, item.Item2))
-                            {
-                                yield return item;
-                            }
+                            yield return item;
                         }
                     }
                 }


### PR DESCRIPTION
# Description

Hi,
This pull request simplify the iteration logic in the method GetEnumerator().
Thank you for your attention to these changes.

Best regards,
Aymeric

## Changes:

Simplified the iteration logic in the method enclosed by lock (SyncRoot) by consolidating two similar foreach loops into one using a ternary operator to handle reverse iteration conditionally.

###  Before : 
```cs
if (!reverse)
{
    foreach (var item in list)
    {
        if (filter.IsMatch(item.Item1, item.Item2))
        {
            yield return item;
        }
    }
}
else
{
    foreach (var item in list.AsEnumerable().Reverse())
    {
        if (filter.IsMatch(item.Item1, item.Item2))
        {
            yield return item;
        }
    }
}
```
### After : 
```cs
foreach (var item in reverse ? list.AsEnumerable().Reverse() : list)
{
    if (filter.IsMatch(item.Item1, item.Item2))
    {
        yield return item;
    }
}
```
## Note
if you prefer, I can also extract the ternary into a variable before the foreach loop