### PR TITLE
fix ResizableArray

### DIFF
--- a/src/ObservableCollections/Internal/ResizableArray.cs
+++ b/src/ObservableCollections/Internal/ResizableArray.cs
@@ -33,8 +33,10 @@ namespace ObservableCollections.Internal
         [MethodImpl(MethodImplOptions.NoInlining)]
         void EnsureCapacity()
         {
-            var newArray = array.AsSpan().ToArray();
-            ArrayPool<T>.Shared.Return(array!, RuntimeHelpersEx.IsReferenceOrContainsReferences<T>());
+            var oldArray = array!;
+            var newArray = ArrayPool<T>.Shared.Rent(oldArray.Length * 2);
+            Array.Copy(oldArray, newArray, oldArray.Length);
+            ArrayPool<T>.Shared.Return(oldArray, RuntimeHelpersEx.IsReferenceOrContainsReferences<T>());
             array = newArray;
         }
 


### PR DESCRIPTION
IndexOutOfRangeException was thrown in some cases when executing `ObservableHashSet.AddRange`.
```csharp
static IEnumerable<int> Range(int count)
{
    foreach (var i in Enumerable.Range(0, count))
    {
        yield return i;
    }
}

var set = new ObservableHashSet<int>();
set.AddRange(Range(20));
```
The reason is that when `ResizableArray<T>.EnsureCapacity` is executed, the capacity of the new array equals the capacity of the old array.
Therefore, I modified it to create a new array with twice the capacity of the old one.