### PR TITLE
Add IReadOnlyObservableList interface

### DIFF
--- a/src/ObservableCollections/IObservableCollection.cs
+++ b/src/ObservableCollections/IObservableCollection.cs
@@ -15,6 +15,11 @@ namespace ObservableCollections
         ISynchronizedView<T, TView> CreateView<TView>(Func<T, TView> transform, bool reverse = false);
     }
 
+    public interface IReadOnlyObservableList<T> :
+        IReadOnlyList<T>, IObservableCollection<T>
+    {
+    }
+
     public interface IReadOnlyObservableDictionary<TKey, TValue> : 
         IReadOnlyDictionary<TKey, TValue>, IObservableCollection<KeyValuePair<TKey, TValue>>
     {

--- a/src/ObservableCollections/ObservableList.Views.cs
+++ b/src/ObservableCollections/ObservableList.Views.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 namespace ObservableCollections
 {
-    public sealed partial class ObservableList<T> : IList<T>, IReadOnlyList<T>, IObservableCollection<T>
+    public sealed partial class ObservableList<T> : IList<T>, IReadOnlyObservableList<T>
     {
         public ISynchronizedView<T, TView> CreateView<TView>(Func<T, TView> transform, bool reverse = false)
         {

--- a/src/ObservableCollections/ObservableList.cs
+++ b/src/ObservableCollections/ObservableList.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 
 namespace ObservableCollections
 {
-    public sealed partial class ObservableList<T> : IList<T>, IReadOnlyList<T>, IObservableCollection<T>
+    public sealed partial class ObservableList<T> : IList<T>, IReadOnlyObservableList<T>
     {
         readonly List<T> list;
         public object SyncRoot { get; } = new();


### PR DESCRIPTION
Related to #45, `IReadOnlyReactiveCollection<T>` in UniRx has an indexer definition, but `IObservableCollection<T>` does not have an equivalent definition.

Therefore, I added `IReadOnlyObservableList<T>` as an interface to handle both `IReadOnlyList<T>` and `IObservableCollection<T>`.