### PR TITLE
Add missing equality comparer parameter and getter

### DIFF
--- a/src/ObservableCollections/ObservableDictionary.cs
+++ b/src/ObservableCollections/ObservableDictionary.cs
@@ -224,5 +224,16 @@ namespace ObservableCollections
         {
             return GetEnumerator();
         }
+
+        public IEqualityComparer<TKey> Comparer
+        {
+            get
+            {
+                lock (SyncRoot)
+                {
+                    return dictionary.Comparer;
+                }
+            }
+        }
     }
 }

--- a/src/ObservableCollections/ObservableDictionary.cs
+++ b/src/ObservableCollections/ObservableDictionary.cs
@@ -13,17 +13,17 @@ namespace ObservableCollections
         readonly Dictionary<TKey, TValue> dictionary;
         public object SyncRoot { get; } = new object();
 
-        public ObservableDictionary()
+        public ObservableDictionary(IEqualityComparer<TKey>? comparer = null)
         {
-            this.dictionary = new Dictionary<TKey, TValue>();
+            this.dictionary = new Dictionary<TKey, TValue>(comparer: comparer);
         }
 
-        public ObservableDictionary(IEnumerable<KeyValuePair<TKey, TValue>> collection)
+        public ObservableDictionary(IEnumerable<KeyValuePair<TKey, TValue>> collection, IEqualityComparer<TKey>? comparer = null)
         {
-#if NET6_0_OR_GREATER
-            this.dictionary = new Dictionary<TKey, TValue>(collection);
+#if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
+            this.dictionary = new Dictionary<TKey, TValue>(collection: collection, comparer: comparer);
 #else
-            this.dictionary = new Dictionary<TKey, TValue>();
+            this.dictionary = new Dictionary<TKey, TValue>(comparer: comparer);
             foreach (var item in collection)
             {
                 dictionary.Add(item.Key, item.Value);

--- a/src/ObservableCollections/ObservableHashSet.cs
+++ b/src/ObservableCollections/ObservableHashSet.cs
@@ -264,5 +264,16 @@ namespace ObservableCollections
         {
             return GetEnumerator();
         }
+
+        public IEqualityComparer<T> Comparer
+        {
+            get
+            {
+                lock (SyncRoot)
+                {
+                    return set.Comparer;
+                }
+            }
+        }
     }
 }

--- a/src/ObservableCollections/ObservableHashSet.cs
+++ b/src/ObservableCollections/ObservableHashSet.cs
@@ -14,23 +14,23 @@ namespace ObservableCollections
         readonly HashSet<T> set;
         public object SyncRoot { get; } = new object();
 
-        public ObservableHashSet()
+        public ObservableHashSet(IEqualityComparer<T>? comparer = null)
         {
-            this.set = new HashSet<T>();
+            this.set = new HashSet<T>(comparer: comparer);
         }
 
 #if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
 
-        public ObservableHashSet(int capacity)
+        public ObservableHashSet(int capacity, IEqualityComparer<T>? comparer = null)
         {
-            this.set = new HashSet<T>(capacity);
+            this.set = new HashSet<T>(capacity: capacity, comparer: comparer);
         }
 
 #endif
 
-        public ObservableHashSet(IEnumerable<T> collection)
+        public ObservableHashSet(IEnumerable<T> collection, IEqualityComparer<T>? comparer = null)
         {
-            this.set = new HashSet<T>(collection);
+            this.set = new HashSet<T>(collection: collection, comparer: comparer);
         }
 
         public event NotifyCollectionChangedEventHandler<T>? CollectionChanged;


### PR DESCRIPTION
The constructors for both `ObservableHashSet<>` and `ObservableDictionary<,>` were missing the `IEqualityComparer<>` parameter to specify how equality.

I also updated the `ObservableDictionary<,>` constructor that takes an `IEnumerable<KeyValuePair<,>>`. The same constructor on `Dictionary<,>` is also available on .NET Standard 2.1, just not 2.0.