### PR TITLE
Add 'out' keyword in ObservableQueue.TryPeek method

### DIFF
--- a/src/ObservableCollections/ObservableQueue.cs
+++ b/src/ObservableCollections/ObservableQueue.cs
@@ -171,7 +171,7 @@ namespace ObservableCollections
             }
         }
 
-        public bool TryPeek([MaybeNullWhen(false)] T result)
+        public bool TryPeek([MaybeNullWhen(false)] out T result)
         {
             lock (SyncRoot)
             {


### PR DESCRIPTION
Contents of the `Observablequeue.TryPeek([MaybeNullWhen(false)] T result)` function and how to use the basic `TryPeek(out T result)` function of C#, I thought it was a typo without the **out** keyword, so added the keyword in TryPeek function.