### PR TITLE
Add constructors for ObservableDictionary and ObservableHashSet

### DIFF
--- a/src/ObservableCollections/ObservableDictionary.cs
+++ b/src/ObservableCollections/ObservableDictionary.cs
@@ -18,12 +18,56 @@ namespace ObservableCollections
             this.dictionary = new Dictionary<TKey, TValue>();
         }
 
+        public ObservableDictionary(int capacity)
+        {
+            this.dictionary = new Dictionary<TKey, TValue>(capacity);
+        }
+
+        public ObservableDictionary(IEqualityComparer<TKey>? comparer)
+        {
+            this.dictionary = new Dictionary<TKey, TValue>(comparer);
+        }
+
+        public ObservableDictionary(int capacity, IEqualityComparer<TKey>? comparer)
+        {
+            this.dictionary = new Dictionary<TKey, TValue>(capacity, comparer);
+        }
+
         public ObservableDictionary(IEnumerable<KeyValuePair<TKey, TValue>> collection)
         {
 #if NET6_0_OR_GREATER
             this.dictionary = new Dictionary<TKey, TValue>(collection);
 #else
-            this.dictionary = new Dictionary<TKey, TValue>();
+            if (collection.TryGetNonEnumeratedCount(out var count))
+            {
+                this.dictionary = new Dictionary<TKey, TValue>(count);
+            }
+            else
+            {
+                this.dictionary = new Dictionary<TKey, TValue>();
+            }
+
+            foreach (var item in collection)
+            {
+                dictionary.Add(item.Key, item.Value);
+            }
+#endif
+        }
+
+        public ObservableDictionary(IEnumerable<KeyValuePair<TKey, TValue>> collection, IEqualityComparer<TKey>? comparer)
+        {
+#if NET6_0_OR_GREATER
+            this.dictionary = new Dictionary<TKey, TValue>(collection, comparer);
+#else
+            if (collection.TryGetNonEnumeratedCount(out var count))
+            {
+                this.dictionary = new Dictionary<TKey, TValue>(count, comparer);
+            }
+            else
+            {
+                this.dictionary = new Dictionary<TKey, TValue>(comparer);
+            }
+
             foreach (var item in collection)
             {
                 dictionary.Add(item.Key, item.Value);

--- a/src/ObservableCollections/ObservableHashSet.cs
+++ b/src/ObservableCollections/ObservableHashSet.cs
@@ -19,6 +19,11 @@ namespace ObservableCollections
             this.set = new HashSet<T>();
         }
 
+        public ObservableHashSet(IEqualityComparer<T>? comparer)
+        {
+            this.set = new HashSet<T>(comparer);
+        }
+
 #if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
 
         public ObservableHashSet(int capacity)
@@ -26,11 +31,21 @@ namespace ObservableCollections
             this.set = new HashSet<T>(capacity);
         }
 
+        public ObservableHashSet(int capacity, IEqualityComparer<T>? comparer)
+        {
+            this.set = new HashSet<T>(capacity, comparer);
+        }
+
 #endif
 
         public ObservableHashSet(IEnumerable<T> collection)
         {
             this.set = new HashSet<T>(collection);
+        }
+
+        public ObservableHashSet(IEnumerable<T> collection, IEqualityComparer<T>? comparer)
+        {
+            this.set = new HashSet<T>(collection, comparer);
         }
 
         public event NotifyCollectionChangedEventHandler<T>? CollectionChanged;


### PR DESCRIPTION
I have added the following constructors to ObservableDictionary and ObservableHashSet. It might be beneficial when the initial capacity is known in advance or when you want to use a specified  equality comparer.
I think it is also related to Issue [#59](https://github.com/Cysharp/ObservableCollections/issues/59)

```csharp
public ObservableDictionary(int capacity);
public ObservableDictionary(IEqualityComparer<TKey>? comparer);
public ObservableDictionary(int capacity, IEqualityComparer<TKey>? comparer);
public ObservableDictionary(IEnumerable<KeyValuePair<TKey, TValue>> collection, IEqualityComparer<TKey>? comparer);

public ObservableHashSet(IEqualityComparer<T>? comparer);
public ObservableHashSet(int capacity, IEqualityComparer<T>? comparer);
public ObservableHashSet(IEnumerable<T> collection, IEqualityComparer<T>? comparer);
```