### PR TITLE
Fix IList behavior in ListNotifyCollectionChangedSynchronizedView

### DIFF
--- a/src/ObservableCollections/Internal/NotifyCollectionChangedSynchronizedView.cs
+++ b/src/ObservableCollections/Internal/NotifyCollectionChangedSynchronizedView.cs
@@ -161,12 +161,12 @@ namespace ObservableCollections.Internal
                             if (currentIndex == index)
                             {
                                 return itemView;
-                }
+                            }
                             currentIndex++;
                         }
                     }
                     throw new ArgumentOutOfRangeException(nameof(index));
-            }
+                }
             }
             set => throw new NotSupportedException();
         }
@@ -243,11 +243,11 @@ namespace ObservableCollections.Internal
                     if (view.CurrentFilter.IsMatch(value, itemView))
                     {
                         if (EqualityComparer<TView>.Default.Equals(itemView, item))
-                    {
-                        return true;
+                        {
+                            return true;
+                        }
                     }
                 }
-            }
             }
             return false;
         }
@@ -279,14 +279,14 @@ namespace ObservableCollections.Internal
                 foreach (var (value, itemView) in view.list)
                 {
                     if (view.CurrentFilter.IsMatch(value, itemView))
-                {
-                        if (EqualityComparer<TView>.Default.Equals(itemView, item))
                     {
-                        return index;
+                        if (EqualityComparer<TView>.Default.Equals(itemView, item))
+                        {
+                            return index;
+                        }
+                        index++;
                     }
-                    index++;
                 }
-            }
             }
             return -1;
         }


### PR DESCRIPTION
#58 and [issue with filtering in WPF](https://github.com/runceel/ReactiveProperty/issues/487#issuecomment-2291369293), by revising the retrieval of IList, the apparent behavior is working well.
It may be necessary to make speed-related improvements, such as internally maintaining a filtered list.