### PR TITLE
Add INotifyCollectionChangedSynchronizedView.Refresh()

### DIFF
--- a/src/ObservableCollections/IObservableCollection.cs
+++ b/src/ObservableCollections/IObservableCollection.cs
@@ -59,6 +59,7 @@ namespace ObservableCollections
 
     public interface INotifyCollectionChangedSynchronizedView<out TView> : IReadOnlyCollection<TView>, INotifyCollectionChanged, INotifyPropertyChanged, IDisposable
     {
+        void Refresh();
     }
 
     public static class ObservableCollectionsExtensions

--- a/src/ObservableCollections/Internal/NotifyCollectionChangedSynchronizedView.cs
+++ b/src/ObservableCollections/Internal/NotifyCollectionChangedSynchronizedView.cs
@@ -131,6 +131,11 @@ namespace ObservableCollections.Internal
                 self.PropertyChanged?.Invoke(self, CountPropertyChangedEventArgs);
             }
         }
+
+        public void Refresh()
+        {
+            OnCollectionChanged(new SynchronizedViewChangedEventArgs<T, TView>(NotifyCollectionChangedAction.Reset));
+        }
     }
 
     internal class ListNotifyCollectionChangedSynchronizedView<T, TView>


### PR DESCRIPTION
When updating the filtering, it was necessary to call ToNotifyCollectionChanged() each time, but this can now be eliminated.
Additionally, the implementation of INotifyPropertyChanged in the ViewModel's properties can also be removed.