### PR TITLE
Fix #58 IsCompatibleObject

### DIFF
--- a/src/ObservableCollections/Internal/NotifyCollectionChangedSynchronizedView.cs
+++ b/src/ObservableCollections/Internal/NotifyCollectionChangedSynchronizedView.cs
@@ -169,7 +169,7 @@ namespace ObservableCollections.Internal
 
         static bool IsCompatibleObject(object? value)
         {
-            return (value is T) || (value == null && default(T) == null);
+            return (value is TView) || (value is T) || (value == null && default(T) == null);
         }
 
         public bool IsReadOnly => true;


### PR DESCRIPTION
#58 
Fixed an issue where `IsCompatibleObject()` was always false when `T` and `TView` were different types.
This allowed `Contains()` to work correctly and resolve the issue.