### PR TITLE
Add ISynchronizedView.Refresh()

### DIFF
--- a/src/ObservableCollections/IObservableCollection.cs
+++ b/src/ObservableCollections/IObservableCollection.cs
@@ -38,6 +38,7 @@ namespace ObservableCollections
 
         void AttachFilter(ISynchronizedViewFilter<T> filter);
         void ResetFilter();
+        void Refresh();
         ISynchronizedViewList<TView> ToViewList();
         INotifyCollectionChangedSynchronizedViewList<TView> ToNotifyCollectionChanged();
         INotifyCollectionChangedSynchronizedViewList<TView> ToNotifyCollectionChanged(ICollectionEventDispatcher? collectionEventDispatcher);

--- a/src/ObservableCollections/ObservableDictionary.Views.cs
+++ b/src/ObservableCollections/ObservableDictionary.Views.cs
@@ -106,9 +106,18 @@ namespace ObservableCollections
                     this.filteredCount = dict.Count;
                     ViewChanged?.Invoke(new SynchronizedViewChangedEventArgs<KeyValuePair<TKey, TValue>, TView>(NotifyCollectionChangedAction.Reset, true));
                 }
-            }
+			}
 
-            public ISynchronizedViewList<TView> ToViewList()
+			public void Refresh()
+			{
+				if (filter.IsNullFilter())
+				{
+					return;
+				}
+				AttachFilter(filter);
+			}
+
+			public ISynchronizedViewList<TView> ToViewList()
             {
                 return new FiltableSynchronizedViewList<KeyValuePair<TKey, TValue>, TView>(this);
             }

--- a/src/ObservableCollections/ObservableDictionary.Views.cs
+++ b/src/ObservableCollections/ObservableDictionary.Views.cs
@@ -106,18 +106,18 @@ namespace ObservableCollections
                     this.filteredCount = dict.Count;
                     ViewChanged?.Invoke(new SynchronizedViewChangedEventArgs<KeyValuePair<TKey, TValue>, TView>(NotifyCollectionChangedAction.Reset, true));
                 }
-			}
+            }
 
-			public void Refresh()
-			{
-				if (filter.IsNullFilter())
-				{
-					return;
-				}
-				AttachFilter(filter);
-			}
+            public void Refresh()
+            {
+                if (filter.IsNullFilter())
+                {
+                    return;
+                }
+                AttachFilter(filter);
+            }
 
-			public ISynchronizedViewList<TView> ToViewList()
+            public ISynchronizedViewList<TView> ToViewList()
             {
                 return new FiltableSynchronizedViewList<KeyValuePair<TKey, TValue>, TView>(this);
             }

--- a/src/ObservableCollections/ObservableHashSet.Views.cs
+++ b/src/ObservableCollections/ObservableHashSet.Views.cs
@@ -101,18 +101,18 @@ namespace ObservableCollections
                     this.filteredCount = dict.Count;
                     ViewChanged?.Invoke(new SynchronizedViewChangedEventArgs<T, TView>(NotifyCollectionChangedAction.Reset, true));
                 }
-			}
+            }
 
-			public void Refresh()
-			{
-				if (filter.IsNullFilter())
-				{
-					return;
-				}
-				AttachFilter(filter);
-			}
+            public void Refresh()
+            {
+                if (filter.IsNullFilter())
+                {
+                    return;
+                }
+                AttachFilter(filter);
+            }
 
-			public ISynchronizedViewList<TView> ToViewList()
+            public ISynchronizedViewList<TView> ToViewList()
             {
                 return new FiltableSynchronizedViewList<T, TView>(this);
             }

--- a/src/ObservableCollections/ObservableHashSet.Views.cs
+++ b/src/ObservableCollections/ObservableHashSet.Views.cs
@@ -101,9 +101,18 @@ namespace ObservableCollections
                     this.filteredCount = dict.Count;
                     ViewChanged?.Invoke(new SynchronizedViewChangedEventArgs<T, TView>(NotifyCollectionChangedAction.Reset, true));
                 }
-            }
+			}
 
-            public ISynchronizedViewList<TView> ToViewList()
+			public void Refresh()
+			{
+				if (filter.IsNullFilter())
+				{
+					return;
+				}
+				AttachFilter(filter);
+			}
+
+			public ISynchronizedViewList<TView> ToViewList()
             {
                 return new FiltableSynchronizedViewList<T, TView>(this);
             }

--- a/src/ObservableCollections/ObservableList.Views.cs
+++ b/src/ObservableCollections/ObservableList.Views.cs
@@ -104,18 +104,18 @@ namespace ObservableCollections
                     this.filteredCount = list.Count;
                     ViewChanged?.Invoke(new SynchronizedViewChangedEventArgs<T, TView>(NotifyCollectionChangedAction.Reset, true));
                 }
-			}
+            }
 
-			public void Refresh()
-			{
-				if (filter.IsNullFilter())
-				{
-					return;
-				}
+            public void Refresh()
+            {
+                if (filter.IsNullFilter())
+                {
+                    return;
+                }
                 AttachFilter(filter);
-			}
+            }
 
-			public ISynchronizedViewList<TView> ToViewList()
+            public ISynchronizedViewList<TView> ToViewList()
             {
                 return new FiltableSynchronizedViewList<T, TView>(this);
             }

--- a/src/ObservableCollections/ObservableList.Views.cs
+++ b/src/ObservableCollections/ObservableList.Views.cs
@@ -104,9 +104,18 @@ namespace ObservableCollections
                     this.filteredCount = list.Count;
                     ViewChanged?.Invoke(new SynchronizedViewChangedEventArgs<T, TView>(NotifyCollectionChangedAction.Reset, true));
                 }
-            }
+			}
 
-            public ISynchronizedViewList<TView> ToViewList()
+			public void Refresh()
+			{
+				if (filter.IsNullFilter())
+				{
+					return;
+				}
+                AttachFilter(filter);
+			}
+
+			public ISynchronizedViewList<TView> ToViewList()
             {
                 return new FiltableSynchronizedViewList<T, TView>(this);
             }

--- a/src/ObservableCollections/ObservableQueue.Views.cs
+++ b/src/ObservableCollections/ObservableQueue.Views.cs
@@ -103,16 +103,16 @@ namespace ObservableCollections
                 }
             }
 
-			public void Refresh()
-			{
-				if (filter.IsNullFilter())
-				{
-					return;
-				}
-				AttachFilter(filter);
-			}
+            public void Refresh()
+            {
+                if (filter.IsNullFilter())
+                {
+                    return;
+                }
+                AttachFilter(filter);
+            }
 
-			public ISynchronizedViewList<TView> ToViewList()
+            public ISynchronizedViewList<TView> ToViewList()
             {
                 return new FiltableSynchronizedViewList<T, TView>(this);
             }

--- a/src/ObservableCollections/ObservableQueue.Views.cs
+++ b/src/ObservableCollections/ObservableQueue.Views.cs
@@ -103,7 +103,16 @@ namespace ObservableCollections
                 }
             }
 
-            public ISynchronizedViewList<TView> ToViewList()
+			public void Refresh()
+			{
+				if (filter.IsNullFilter())
+				{
+					return;
+				}
+				AttachFilter(filter);
+			}
+
+			public ISynchronizedViewList<TView> ToViewList()
             {
                 return new FiltableSynchronizedViewList<T, TView>(this);
             }

--- a/src/ObservableCollections/ObservableRingBuffer.Views.cs
+++ b/src/ObservableCollections/ObservableRingBuffer.Views.cs
@@ -103,9 +103,18 @@ namespace ObservableCollections
                     this.filteredCount = ringBuffer.Count;
                     ViewChanged?.Invoke(new SynchronizedViewChangedEventArgs<T, TView>(NotifyCollectionChangedAction.Reset, true));
                 }
-            }
+			}
 
-            public ISynchronizedViewList<TView> ToViewList()
+			public void Refresh()
+			{
+				if (filter.IsNullFilter())
+				{
+					return;
+				}
+				AttachFilter(filter);
+			}
+
+			public ISynchronizedViewList<TView> ToViewList()
             {
                 return new FiltableSynchronizedViewList<T, TView>(this);
             }

--- a/src/ObservableCollections/ObservableRingBuffer.Views.cs
+++ b/src/ObservableCollections/ObservableRingBuffer.Views.cs
@@ -103,18 +103,18 @@ namespace ObservableCollections
                     this.filteredCount = ringBuffer.Count;
                     ViewChanged?.Invoke(new SynchronizedViewChangedEventArgs<T, TView>(NotifyCollectionChangedAction.Reset, true));
                 }
-			}
+            }
 
-			public void Refresh()
-			{
-				if (filter.IsNullFilter())
-				{
-					return;
-				}
-				AttachFilter(filter);
-			}
+            public void Refresh()
+            {
+                if (filter.IsNullFilter())
+                {
+                    return;
+                }
+                AttachFilter(filter);
+            }
 
-			public ISynchronizedViewList<TView> ToViewList()
+            public ISynchronizedViewList<TView> ToViewList()
             {
                 return new FiltableSynchronizedViewList<T, TView>(this);
             }

--- a/src/ObservableCollections/ObservableStack.Views.cs
+++ b/src/ObservableCollections/ObservableStack.Views.cs
@@ -100,18 +100,18 @@ namespace ObservableCollections
                     this.filteredCount = stack.Count;
                     ViewChanged?.Invoke(new SynchronizedViewChangedEventArgs<T, TView>(NotifyCollectionChangedAction.Reset, true));
                 }
-			}
+            }
 
-			public void Refresh()
-			{
-				if (filter.IsNullFilter())
-				{
-					return;
-				}
-				AttachFilter(filter);
-			}
+            public void Refresh()
+            {
+                if (filter.IsNullFilter())
+                {
+                    return;
+                }
+                AttachFilter(filter);
+            }
 
-			public ISynchronizedViewList<TView> ToViewList()
+            public ISynchronizedViewList<TView> ToViewList()
             {
                 return new FiltableSynchronizedViewList<T, TView>(this);
             }

--- a/src/ObservableCollections/ObservableStack.Views.cs
+++ b/src/ObservableCollections/ObservableStack.Views.cs
@@ -100,9 +100,18 @@ namespace ObservableCollections
                     this.filteredCount = stack.Count;
                     ViewChanged?.Invoke(new SynchronizedViewChangedEventArgs<T, TView>(NotifyCollectionChangedAction.Reset, true));
                 }
-            }
+			}
 
-            public ISynchronizedViewList<TView> ToViewList()
+			public void Refresh()
+			{
+				if (filter.IsNullFilter())
+				{
+					return;
+				}
+				AttachFilter(filter);
+			}
+
+			public ISynchronizedViewList<TView> ToViewList()
             {
                 return new FiltableSynchronizedViewList<T, TView>(this);
             }


### PR DESCRIPTION
When there is a variable inside the filter function passed to AttachFilter,
there is no method to invoke the ViewChanged or update the filteredCount when the variable is modified.
To reapply the filter, you need to pass the same filter function to AttachFilter again.