### PR TITLE
add overload, and change the order of arguments

### DIFF
--- a/src/ObservableCollections/IObservableCollection.cs
+++ b/src/ObservableCollections/IObservableCollection.cs
@@ -58,6 +58,7 @@ namespace ObservableCollections
         void SetToSourceCollection(int index, T value);
         IWritableSynchronizedViewList<TView> ToWritableViewList(WritableViewChangedEventHandler<T, TView> converter);
         INotifyCollectionChangedSynchronizedViewList<TView> ToWritableNotifyCollectionChanged(WritableViewChangedEventHandler<T, TView> converter);
+        INotifyCollectionChangedSynchronizedViewList<TView> ToWritableNotifyCollectionChanged(ICollectionEventDispatcher? collectionEventDispatcher);
         INotifyCollectionChangedSynchronizedViewList<TView> ToWritableNotifyCollectionChanged(WritableViewChangedEventHandler<T, TView> converter, ICollectionEventDispatcher? collectionEventDispatcher);
     }
 

--- a/src/ObservableCollections/ObservableList.Views.cs
+++ b/src/ObservableCollections/ObservableList.Views.cs
@@ -26,19 +26,22 @@ namespace ObservableCollections
 
         public INotifyCollectionChangedSynchronizedViewList<T> ToWritableNotifyCollectionChanged(ICollectionEventDispatcher? collectionEventDispatcher)
         {
-            return ToWritableNotifyCollectionChanged(static x => x, collectionEventDispatcher, static (T newView, T originalValue, ref bool setValue) =>
-            {
-                setValue = true;
-                return newView;
-            });
+            return ToWritableNotifyCollectionChanged(
+                static x => x,
+                static (T newView, T originalValue, ref bool setValue) =>
+                {
+                    setValue = true;
+                    return newView;
+                },
+                collectionEventDispatcher);
         }
 
         public INotifyCollectionChangedSynchronizedViewList<TView> ToWritableNotifyCollectionChanged<TView>(Func<T, TView> transform, WritableViewChangedEventHandler<T, TView>? converter)
         {
-            return ToWritableNotifyCollectionChanged(transform, null!);
+            return ToWritableNotifyCollectionChanged(transform, converter, null!);
         }
 
-        public INotifyCollectionChangedSynchronizedViewList<TView> ToWritableNotifyCollectionChanged<TView>(Func<T, TView> transform, ICollectionEventDispatcher? collectionEventDispatcher, WritableViewChangedEventHandler<T, TView>? converter)
+        public INotifyCollectionChangedSynchronizedViewList<TView> ToWritableNotifyCollectionChanged<TView>(Func<T, TView> transform, WritableViewChangedEventHandler<T, TView>? converter, ICollectionEventDispatcher? collectionEventDispatcher)
         {
             return new NonFilteredNotifyCollectionChangedSynchronizedViewList<T, TView>(CreateView(transform), collectionEventDispatcher, converter);
         }
@@ -367,9 +370,19 @@ namespace ObservableCollections
                 return new NotifyCollectionChangedSynchronizedViewList<T, TView>(this, null, converter);
             }
 
+            public INotifyCollectionChangedSynchronizedViewList<TView> ToWritableNotifyCollectionChanged(ICollectionEventDispatcher? collectionEventDispatcher)
+            {
+                return new NotifyCollectionChangedSynchronizedViewList<T, TView>(this, collectionEventDispatcher,
+                                                                                 static (TView newView, T originalValue, ref bool setValue) =>
+                                                                                 {
+                                                                                     setValue = true;
+                                                                                     return originalValue;
+                                                                                 });
+            }
+
             public INotifyCollectionChangedSynchronizedViewList<TView> ToWritableNotifyCollectionChanged(WritableViewChangedEventHandler<T, TView> converter, ICollectionEventDispatcher? collectionEventDispatcher)
             {
-                return new NotifyCollectionChangedSynchronizedViewList<T, TView>(this, null, converter);
+                return new NotifyCollectionChangedSynchronizedViewList<T, TView>(this, collectionEventDispatcher, converter);
             }
 
             #endregion


### PR DESCRIPTION
# Add and Modify Overloads for ToWritableNotifyCollectionChanged

## Changes Overview

1. Added methods to `Filtable` that can operate without the `converter` parameter that exists in `NonFiltered`
2. Standardized parameter order between `Filtable` and `NonFilter` methods
   - Unified order: `WritableViewChangedEventHandler<T, TView>?, ICollectionEventDispatcher?`
   - Note: Considering the pattern in `NotifyCollectionChangedSynchronizedViewList`, reversing this order might be more appropriate

3. Fixed issue where `converter` parameter wasn't being passed in `NonFilter`
4. Fixed issue where `collectionEventDispatcher` wasn't being passed in `Filtable`

## Technical Details
These modifications improve the consistency and functionality of the `ToWritableNotifyCollectionChanged` method overloads, ensuring better usability and proper parameter handling across different scenarios.


## Related Issues
- Issue #75

Please review and provide feedback on these changes.