### PR TITLE
Improve synchronization handling in event dispatcher

### DIFF
--- a/src/ObservableCollections/ICollectionEventDispatcher.cs
+++ b/src/ObservableCollections/ICollectionEventDispatcher.cs
@@ -35,7 +35,16 @@ namespace ObservableCollections
 
         public void Post(CollectionEventDispatcherEventArgs ev)
         {
-            synchronizationContext.Post(callback, ev);
+            if (SynchronizationContext.Current == null)
+            {
+                // non-UI thread, post the event asynchronously
+                synchronizationContext.Post(callback, ev);
+            }
+            else
+            {
+                // UI thread, send the event synchronously
+                synchronizationContext.Send(callback, ev);
+            }
         }
 
         static void SendOrPostCallback(object? state)


### PR DESCRIPTION
I apologize for the consecutive pull requests.

Regarding `WritableView`, I noticed that an exception occurs when adding items to the DataGrid while using `ToWritableNotifyCollectionChanged(SynchronizationContextCollectionEventDispatcher.Current)`.

Upon checking, it seems necessary to separate the handling of UI operations on the DataGrid and asynchronous collection operations in `SynchronizationContextCollectionEventDispatcher.Post()`.

The UI operations and asynchronous collection operations worked fine with the code in this PR, but I am concerned about whether this code is appropriate and if there are any unintended consequences.

Let me know if you need any tweaks!