### PR TITLE
chore: Specify IsPackable=false on Directory.Build.props, explicitly true for target packages.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,7 +57,7 @@ _ReSharper*
 *.ncrunch*
 .*crunch*.local.xml
 
-# Installshield output folder 
+# Installshield output folder
 [Ee]xpress
 
 # DocProject is a documentation generator add-in
@@ -77,7 +77,19 @@ publish
 *.Publish.xml
 
 # NuGet Packages Directory
+*.nupkg
+# NuGet Symbol Packages
+*.snupkg
+# The packages folder can be ignored because of Package Restore
 # packages # upm pacakge will use Packages
+# **/[Pp]ackages/*
+# except build/, which is used as an MSBuild target.
+# !**/[Pp]ackages/build/
+# Uncomment if necessary however generally it will be regenerated when needed
+#!**/[Pp]ackages/repositories.config
+# NuGet v3's project.json files produces more ignorable files
+*.nuget.props
+*.nuget.targets
 
 # Windows Azure Build Output
 csx
@@ -107,9 +119,6 @@ UpgradeLog*.XML
 .vs/config/applicationhost.config
 .vs/restore.dg
 
-nuget/tools/*
-nuget/*.nupkg
-nuget/*.unitypackage
 .vs/
 
 # Jetbrains Rider

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,9 +4,11 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
 
     <!-- NuGet Packaging -->
+    <IsPackable>false</IsPackable>
     <PackageVersion>$(Version)</PackageVersion>
     <Company>Cysharp</Company>
     <Authors>Cysharp</Authors>
+    <PackageTags>collection</PackageTags>
     <Copyright>© Cysharp, Inc.</Copyright>
     <PackageProjectUrl>https://github.com/Cysharp/ObservableCollections</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -18,6 +20,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)Icon.png" Pack="true" PackagePath="\" />
     <None Include="$(MSBuildThisFileDirectory)README.md" Pack="true" PackagePath="\" />
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)LICENSE" />
   </ItemGroup>
 </Project>

--- a/sandbox/AvaloniaApp/AvaloniaApp.csproj
+++ b/sandbox/AvaloniaApp/AvaloniaApp.csproj
@@ -1,29 +1,25 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-	<PropertyGroup>
-		<OutputType>WinExe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
-		<Nullable>enable</Nullable>
-		<BuiltInComInteropSupport>true</BuiltInComInteropSupport>
-		<ApplicationManifest>app.manifest</ApplicationManifest>
-		<AvaloniaUseCompiledBindingsByDefault>false</AvaloniaUseCompiledBindingsByDefault>
-		<IsPackable>false</IsPackable>
-	</PropertyGroup>
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <AvaloniaUseCompiledBindingsByDefault>false</AvaloniaUseCompiledBindingsByDefault>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="R3Extensions.Avalonia" Version="1.2.5" />
-	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="R3Extensions.Avalonia" Version="1.2.5" />
+    <PackageReference Include="Avalonia" Version="11.1.0" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.1.0" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.1.0" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.1.0" />
+    <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.1.0" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Avalonia" Version="11.1.0" />
-		<PackageReference Include="Avalonia.Desktop" Version="11.1.0" />
-		<PackageReference Include="Avalonia.Themes.Fluent" Version="11.1.0" />
-		<PackageReference Include="Avalonia.Fonts.Inter" Version="11.1.0" />
-		<!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-		<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.1.0" />
-	</ItemGroup>
-
-	<ItemGroup>
-	  <ProjectReference Include="..\..\src\ObservableCollections.R3\ObservableCollections.R3.csproj" />
-	  <ProjectReference Include="..\..\src\ObservableCollections\ObservableCollections.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ObservableCollections.R3\ObservableCollections.R3.csproj" />
+    <ProjectReference Include="..\..\src\ObservableCollections\ObservableCollections.csproj" />
+  </ItemGroup>
 </Project>

--- a/sandbox/BlazorApp/BlazorApp.csproj
+++ b/sandbox/BlazorApp/BlazorApp.csproj
@@ -1,13 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
-    <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <IsPackable>false</IsPackable>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="..\..\src\ObservableCollections\ObservableCollections.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ObservableCollections\ObservableCollections.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/sandbox/ConsoleApp/ConsoleApp.csproj
+++ b/sandbox/ConsoleApp/ConsoleApp.csproj
@@ -1,17 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
-		<LangVersion>10.0</LangVersion>
-		<Nullable>enable</Nullable>
-		<IsPackable>false</IsPackable>
-	</PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>10.0</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\..\src\ObservableCollections.R3\ObservableCollections.R3.csproj" />
-		<ProjectReference Include="..\..\src\ObservableCollections\ObservableCollections.csproj" />
-		<PackageReference Include="R3" Version="1.0.0" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ObservableCollections.R3\ObservableCollections.R3.csproj" />
+    <ProjectReference Include="..\..\src\ObservableCollections\ObservableCollections.csproj" />
+    <PackageReference Include="R3" Version="1.0.0" />
+  </ItemGroup>
 
 </Project>

--- a/sandbox/WinUI3App/WinUI3App.csproj
+++ b/sandbox/WinUI3App/WinUI3App.csproj
@@ -12,7 +12,6 @@
     <Nullable>enable</Nullable>
     <WindowsPackageType>None</WindowsPackageType>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="MainPage.xaml" />

--- a/sandbox/WpfApp/WpfApp.csproj
+++ b/sandbox/WpfApp/WpfApp.csproj
@@ -1,21 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<OutputType>WinExe</OutputType>
-		<TargetFramework>net6.0-windows</TargetFramework>
-		<LangVersion>12</LangVersion>
-		<Nullable>enable</Nullable>
-		<UseWPF>true</UseWPF>
-		<IsPackable>false</IsPackable>
-		<EnableWindowsTargeting>true</EnableWindowsTargeting>
-	</PropertyGroup>
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net6.0-windows</TargetFramework>
+    <LangVersion>12</LangVersion>
+    <Nullable>enable</Nullable>
+    <UseWPF>true</UseWPF>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="R3Extensions.WPF" Version="1.0.4" />
-	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="R3Extensions.WPF" Version="1.0.4" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\..\src\ObservableCollections\ObservableCollections.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ObservableCollections\ObservableCollections.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/src/ObservableCollections.R3/ObservableCollections.R3.csproj
+++ b/src/ObservableCollections.R3/ObservableCollections.R3.csproj
@@ -1,32 +1,26 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0</TargetFrameworks>
-		<ImplicitUsings>disable</ImplicitUsings>
-		<Nullable>enable</Nullable>
-		<LangVersion>12</LangVersion>
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0</TargetFrameworks>
+    <LangVersion>12</LangVersion>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>enable</Nullable>
 
-		<!-- NuGet Packaging -->
-		<PackageTags>collection</PackageTags>
-		<Description>R3 Extensions of ObservableCollections.</Description>
-		<SignAssembly>true</SignAssembly>
-		<IsPackable>true</IsPackable>
-	</PropertyGroup>
+    <!-- NuGet Packaging -->
+    <Description>R3 Extensions of ObservableCollections.</Description>
+    <SignAssembly>true</SignAssembly>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="PolySharp" Version="1.14.1">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="R3" Version="1.0.0" />
-	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="PolySharp" Version="1.14.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="R3" Version="1.0.0" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\ObservableCollections\ObservableCollections.csproj" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<None Include="../../Icon.png" Pack="true" PackagePath="/" />
-		<EmbeddedResource Include="..\..\LICENSE" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ObservableCollections\ObservableCollections.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/ObservableCollections/ObservableCollections.csproj
+++ b/src/ObservableCollections/ObservableCollections.csproj
@@ -1,35 +1,29 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0</TargetFrameworks>
-		<Nullable>enable</Nullable>
-		<LangVersion>12.0</LangVersion>
-		<ImplicitUsings>disable</ImplicitUsings>
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0</TargetFrameworks>
+    <LangVersion>12</LangVersion>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>enable</Nullable>
 
-		<!-- NuGet Packaging -->
-		<PackageTags>collection</PackageTags>
-		<Description>High performance observable collections and synchronized views, for WPF, Blazor, Unity.</Description>
-		<SignAssembly>true</SignAssembly>
-		<IsPackable>true</IsPackable>
-	</PropertyGroup>
+    <!-- NuGet Packaging -->
+    <Description>High performance observable collections and synchronized views, for WPF, Blazor, Unity.</Description>
+    <SignAssembly>true</SignAssembly>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
 
-	<ItemGroup Condition="$(TargetFramework) == 'netstandard2.0'">
-		<PackageReference Include="System.Memory" Version="4.5.4" />
-		<PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
-	</ItemGroup>
-	<ItemGroup Condition="$(TargetFramework) == 'netstandard2.1'">
-		<PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
-	</ItemGroup>
+  <ItemGroup Condition="$(TargetFramework) == 'netstandard2.0'">
+    <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition="$(TargetFramework) == 'netstandard2.1'">
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<None Include="../../Icon.png" Pack="true" PackagePath="/" />
-		<EmbeddedResource Include="..\..\LICENSE" />
-	</ItemGroup>
-
-	<ItemGroup>
-	  <PackageReference Include="PolySharp" Version="1.14.1">
-	    <PrivateAssets>all</PrivateAssets>
-	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-	  </PackageReference>
-	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="PolySharp" Version="1.14.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 </Project>

--- a/tests/ObservableCollections.R3.Tests/ObservableCollections.R3.Tests.csproj
+++ b/tests/ObservableCollections.R3.Tests/ObservableCollections.R3.Tests.csproj
@@ -1,26 +1,25 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
-        <Nullable>enable</Nullable>
-        <IsPackable>false</IsPackable>
-        <IsTestProject>true</IsTestProject>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.12.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0"/>
-		<PackageReference Include="R3" Version="1.0.0" />
-        <PackageReference Include="xunit" Version="2.4.2"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0"/>
+    <PackageReference Include="R3" Version="1.0.0" />
+    <PackageReference Include="xunit" Version="2.4.2"/>
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\..\src\ObservableCollections.R3\ObservableCollections.R3.csproj" />
-      <ProjectReference Include="..\..\src\ObservableCollections\ObservableCollections.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ObservableCollections.R3\ObservableCollections.R3.csproj" />
+    <ProjectReference Include="..\..\src\ObservableCollections\ObservableCollections.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/tests/ObservableCollections.Tests/ObservableCollections.Tests.csproj
+++ b/tests/ObservableCollections.Tests/ObservableCollections.Tests.csproj
@@ -1,22 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
-        <IsPackable>false</IsPackable>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.0.0-beta0001" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.0.0-beta0001" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\..\src\ObservableCollections\ObservableCollections.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+   <ProjectReference Include="..\..\src\ObservableCollections\ObservableCollections.csproj" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

Change IsPackable from default, implicitly `true`, to explicitly `false`.
This prevent unintended nuget package generation like sandbox, benchmark, and etc....

Side effect:

- nupkg csproj required to specify `<IsPackable>true</IsPackable>`. Previously they are omitted.
- LICENSE.md is now handled by Directory.Build.props
