### PR TITLE
✨ Add ObservableSortedSet

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ObservableCollections
 [![GitHub Actions](https://github.com/Cysharp/ObservableCollections/workflows/Build-Debug/badge.svg)](https://github.com/Cysharp/ObservableCollections/actions) [![Releases](https://img.shields.io/github/release/Cysharp/ObservableCollections.svg)](https://github.com/Cysharp/ObservableCollections/releases)
 
-ObservableCollections is a high performance observable collections(`ObservableList<T>`, `ObservableDictionary<TKey, TValue>`, `ObservableHashSet<T>`, `ObservableQueue<T>`, `ObservableStack<T>`, `ObservableRingBuffer<T>`, `ObservableFixedSizeRingBuffer<T>`) with synchronized views and Observe Extension for [R3](https://github.com/Cysharp/R3).
+ObservableCollections is a high performance observable collections(`ObservableList<T>`, `ObservableDictionary<TKey, TValue>`, `ObservableHashSet<T>`, `ObservableSortedSet<T>`, `ObservableQueue<T>`, `ObservableStack<T>`, `ObservableRingBuffer<T>`, `ObservableFixedSizeRingBuffer<T>`) with synchronized views and Observe Extension for [R3](https://github.com/Cysharp/R3).
 
 .NET has [`ObservableCollection<T>`](https://docs.microsoft.com/en-us/dotnet/api/system.collections.objectmodel.observablecollection-1), however it has many lacks of features. It based `INotifyCollectionChanged`, `NotifyCollectionChangedEventHandler` and `NotifyCollectionChangedEventArgs`. There are no generics so everything boxed, allocate memory every time. Also `NotifyCollectionChangedEventArgs` holds all values to `IList` even if it is single value, this also causes allocations. `ObservableCollection<T>` has no Range feature so a lot of wastage occurs when adding multiple values, because it is a single value notification.  Also, it is not thread-safe is hard to do linkage with the notifier.
 
@@ -45,7 +45,7 @@ Observable Collections themselves do not implement `INotifyCollectionChanged`, s
 
 ![image](https://github.com/user-attachments/assets/b5590bb8-16d6-4f9c-be07-1288a6801e68)
 
-ObservableCollections has not just a simple list, there are many more data structures. `ObservableList<T>`, `ObservableDictionary<TKey, TValue>`, `ObservableHashSet<T>`, `ObservableQueue<T>`, `ObservableStack<T>`, `ObservableRingBuffer<T>`, `ObservableFixedSizeRingBuffer<T>`. `RingBuffer`, especially `FixedSizeRingBuffer`, can be achieved with efficient performance when there is rotation (e.g., displaying up to 1000 logs, where old ones are deleted when new ones are added). Of course, the AddRange allows for efficient batch processing of large numbers of additions.
+ObservableCollections has not just a simple list, there are many more data structures. `ObservableList<T>`, `ObservableDictionary<TKey, TValue>`, `ObservableHashSet<T>`, `ObservableSortedSet<T>`, `ObservableQueue<T>`, `ObservableStack<T>`, `ObservableRingBuffer<T>`, `ObservableFixedSizeRingBuffer<T>`. `RingBuffer`, especially `FixedSizeRingBuffer`, can be achieved with efficient performance when there is rotation (e.g., displaying up to 1000 logs, where old ones are deleted when new ones are added). Of course, the AddRange allows for efficient batch processing of large numbers of additions.
 
 If you want to handle each change event with Rx, you can monitor it with the following method by combining it with [R3](https://github.com/Cysharp/R3):
 
@@ -68,7 +68,7 @@ For .NET, use NuGet. For Unity, please read [Unity](#unity) section.
 
 > dotnet add package [ObservableCollections](https://www.nuget.org/packages/ObservableCollections)
 
-create new `ObservableList<T>`, `ObservableDictionary<TKey, TValue>`, `ObservableHashSet<T>`, `ObservableQueue<T>`, `ObservableStack<T>`, `ObservableRingBuffer<T>`, `ObservableFixedSizeRingBuffer<T>`.
+create new `ObservableList<T>`, `ObservableDictionary<TKey, TValue>`, `ObservableHashSet<T>`, `ObservableSortedSet<T>`, `ObservableQueue<T>`, `ObservableStack<T>`, `ObservableRingBuffer<T>`, `ObservableFixedSizeRingBuffer<T>`.
 
 ```csharp
 // Basic sample, use like ObservableCollection<T>.
@@ -488,6 +488,7 @@ ObservableCollections provides these collections.
 class ObservableList<T> : IList<T>, IReadOnlyList<T>, IObservableCollection<T>, IReadOnlyObservableList<T>
 class ObservableDictionary<TKey, TValue> : IDictionary<TKey, TValue>, IReadOnlyDictionary<TKey, TValue>, IObservableCollection<KeyValuePair<TKey, TValue>>, IReadOnlyObservableDictionary<TKey, TValue> where TKey : notnull
 class ObservableHashSet<T> : IReadOnlySet<T>, IReadOnlyCollection<T>, IObservableCollection<T> where T : notnull
+class ObservableSortedSet<T> : IReadOnlySet<T>, IReadOnlyCollection<T>, IObservableCollection<T> where T : notnull
 class ObservableQueue<T> : IReadOnlyCollection<T>, IObservableCollection<T>
 class ObservableStack<T> : IReadOnlyCollection<T>, IObservableCollection<T>
 class ObservableRingBuffer<T> : IList<T>, IReadOnlyList<T>, IObservableCollection<T>

--- a/src/ObservableCollections/ObservableSortedSet.Views.cs
+++ b/src/ObservableCollections/ObservableSortedSet.Views.cs
@@ -1,0 +1,232 @@
+using ObservableCollections.Internal;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace ObservableCollections
+{
+    public partial class ObservableSortedSet<T> : IReadOnlyCollection<T>, IObservableCollection<T>
+    {
+        public ISynchronizedView<T, TView> CreateView<TView>(Func<T, TView> transform)
+        {
+            return new View<TView>(this, transform);
+        }
+
+        sealed class View<TView> : ISynchronizedView<T, TView>
+        {
+            public ISynchronizedViewFilter<T, TView> Filter
+            {
+                get { lock (SyncRoot) return filter; }
+            }
+
+            readonly ObservableSortedSet<T> source;
+            readonly Func<T, TView> selector;
+            readonly Dictionary<T, (T, TView)> dict;
+            int filteredCount;
+
+            ISynchronizedViewFilter<T, TView> filter;
+
+            public event NotifyViewChangedEventHandler<T, TView>? ViewChanged;
+            public event Action<RejectedViewChangedAction, int, int>? RejectedViewChanged;
+            public event Action<NotifyCollectionChangedAction>? CollectionStateChanged;
+
+            public object SyncRoot { get; }
+
+            public View(ObservableSortedSet<T> source, Func<T, TView> selector)
+            {
+                this.source = source;
+                this.selector = selector;
+                this.filter = SynchronizedViewFilter<T, TView>.Null;
+                this.SyncRoot = new object();
+                lock (source.SyncRoot)
+                {
+                    this.dict = source.set.ToDictionary(x => x, x => (x, selector(x)));
+                    this.filteredCount = dict.Count;
+                    this.source.CollectionChanged += SourceCollectionChanged;
+                }
+            }
+
+            public int Count
+            {
+                get
+                {
+                    lock (SyncRoot)
+                    {
+                        return filteredCount;
+                    }
+                }
+            }
+
+            public int UnfilteredCount
+            {
+                get
+                {
+                    lock (SyncRoot)
+                    {
+                        return dict.Count;
+                    }
+                }
+            }
+
+            public void AttachFilter(ISynchronizedViewFilter<T, TView> filter)
+            {
+                if (filter.IsNullFilter())
+                {
+                    ResetFilter();
+                    return;
+                }
+
+                lock (SyncRoot)
+                {
+                    this.filter = filter;
+                    this.filteredCount = 0;
+                    foreach (var (_, (value, view)) in dict)
+                    {
+                        if (filter.IsMatch(value, view))
+                        {
+                            filteredCount++;
+                        }
+                    }
+                    ViewChanged?.Invoke(new SynchronizedViewChangedEventArgs<T, TView>(NotifyCollectionChangedAction.Reset, true));
+                }
+            }
+
+            public void ResetFilter()
+            {
+                lock (SyncRoot)
+                {
+                    this.filter = SynchronizedViewFilter<T, TView>.Null;
+                    this.filteredCount = dict.Count;
+                    ViewChanged?.Invoke(new SynchronizedViewChangedEventArgs<T, TView>(NotifyCollectionChangedAction.Reset, true));
+                }
+            }
+
+            public ISynchronizedViewList<TView> ToViewList()
+            {
+                return new FiltableSynchronizedViewList<T, TView>(this, isSupportRangeFeature: true);
+            }
+
+            public NotifyCollectionChangedSynchronizedViewList<TView> ToNotifyCollectionChanged()
+            {
+                return new FiltableSynchronizedViewList<T, TView>(this, isSupportRangeFeature: false);
+            }
+
+            public NotifyCollectionChangedSynchronizedViewList<TView> ToNotifyCollectionChanged(ICollectionEventDispatcher? collectionEventDispatcher)
+            {
+                return new FiltableSynchronizedViewList<T, TView>(this, isSupportRangeFeature: false, collectionEventDispatcher);
+            }
+
+            public IEnumerator<TView> GetEnumerator()
+            {
+                lock (SyncRoot)
+                {
+                    foreach (var item in dict)
+                    {
+                        if (filter.IsMatch(item.Value))
+                        {
+                            yield return item.Value.Item2;
+                        }
+                    }
+                }
+            }
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+            public IEnumerable<(T Value, TView View)> Filtered
+            {
+                get
+                {
+                    lock (SyncRoot)
+                    {
+                        foreach (var item in dict)
+                        {
+                            if (filter.IsMatch(item.Value))
+                            {
+                                yield return item.Value;
+                            }
+                        }
+                    }
+                }
+            }
+
+            public IEnumerable<(T Value, TView View)> Unfiltered
+            {
+                get
+                {
+                    lock (SyncRoot)
+                    {
+                        foreach (var item in dict)
+                        {
+                            yield return item.Value;
+                        }
+                    }
+                }
+            }
+
+            public void Dispose()
+            {
+                this.source.CollectionChanged -= SourceCollectionChanged;
+            }
+
+            private void SourceCollectionChanged(in NotifyCollectionChangedEventArgs<T> e)
+            {
+                lock (SyncRoot)
+                {
+                    switch (e.Action)
+                    {
+                        case NotifyCollectionChangedAction.Add:
+                            if (e.IsSingleItem)
+                            {
+                                var v = (e.NewItem, selector(e.NewItem));
+                                dict.Add(e.NewItem, v);
+                                this.InvokeOnAdd(ref filteredCount, ViewChanged, RejectedViewChanged, v, -1);
+                            }
+                            else
+                            {
+                                var i = e.NewStartingIndex;
+                                foreach (var item in e.NewItems)
+                                {
+                                    var v = (item, selector(item));
+                                    dict.Add(item, v);
+                                    this.InvokeOnAdd(ref filteredCount, ViewChanged, RejectedViewChanged, v, i++);
+                                }
+                            }
+                            break;
+                        case NotifyCollectionChangedAction.Remove:
+                            if (e.IsSingleItem)
+                            {
+                                if (dict.Remove(e.OldItem, out var value))
+                                {
+                                    this.InvokeOnRemove(ref filteredCount, ViewChanged, RejectedViewChanged, value, -1);
+                                }
+                            }
+                            else
+                            {
+                                foreach (var item in e.OldItems)
+                                {
+                                    if (dict.Remove(item, out var value))
+                                    {
+                                        this.InvokeOnRemove(ref filteredCount, ViewChanged, RejectedViewChanged, value, -1);
+                                    }
+                                }
+                            }
+                            break;
+                        case NotifyCollectionChangedAction.Reset:
+                            dict.Clear();
+                            this.InvokeOnReset(ref filteredCount, ViewChanged);
+                            break;
+                        case NotifyCollectionChangedAction.Replace:
+                        case NotifyCollectionChangedAction.Move:
+                        default:
+                            break;
+                    }
+
+                    CollectionStateChanged?.Invoke(e.Action);
+                }
+            }
+        }
+    }
+}

--- a/src/ObservableCollections/ObservableSortedSet.Views.cs
+++ b/src/ObservableCollections/ObservableSortedSet.Views.cs
@@ -182,7 +182,7 @@ namespace ObservableCollections
                             {
                                 var v = (e.NewItem, selector(e.NewItem));
                                 dict.Add(e.NewItem, v);
-                                this.InvokeOnAdd(ref filteredCount, ViewChanged, RejectedViewChanged, v, -1);
+                                this.InvokeOnAdd(ref filteredCount, ViewChanged, RejectedViewChanged, v, e.NewStartingIndex);
                             }
                             else
                             {
@@ -200,16 +200,17 @@ namespace ObservableCollections
                             {
                                 if (dict.Remove(e.OldItem, out var value))
                                 {
-                                    this.InvokeOnRemove(ref filteredCount, ViewChanged, RejectedViewChanged, value, -1);
+                                    this.InvokeOnRemove(ref filteredCount, ViewChanged, RejectedViewChanged, value, e.OldStartingIndex);
                                 }
                             }
                             else
                             {
+                                var i = e.OldStartingIndex;
                                 foreach (var item in e.OldItems)
                                 {
                                     if (dict.Remove(item, out var value))
                                     {
-                                        this.InvokeOnRemove(ref filteredCount, ViewChanged, RejectedViewChanged, value, -1);
+                                        this.InvokeOnRemove(ref filteredCount, ViewChanged, RejectedViewChanged, value, i++);
                                     }
                                 }
                             }

--- a/src/ObservableCollections/ObservableSortedSet.cs
+++ b/src/ObservableCollections/ObservableSortedSet.cs
@@ -1,0 +1,320 @@
+using ObservableCollections.Internal;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+
+namespace ObservableCollections
+{
+    // can not implements ISet<T> because set operation can not get added/removed values.
+    public partial class ObservableSortedSet<T> : IReadOnlySet<T>, IReadOnlyCollection<T>, IObservableCollection<T>
+        where T : notnull
+    {
+        readonly SortedSet<T> set;
+        public object SyncRoot { get; } = new object();
+
+        public ObservableSortedSet()
+        {
+            this.set = new SortedSet<T>();
+        }
+
+        public ObservableSortedSet(IComparer<T>? comparer)
+        {
+            this.set = new SortedSet<T>(comparer: comparer);
+        }
+
+        public ObservableSortedSet(IEnumerable<T> collection)
+        {
+            this.set = new SortedSet<T>(collection: collection);
+        }
+
+        public ObservableSortedSet(IEnumerable<T> collection, IComparer<T>? comparer)
+        {
+            this.set = new SortedSet<T>(collection: collection, comparer: comparer);
+        }
+
+        public event NotifyCollectionChangedEventHandler<T>? CollectionChanged;
+
+        public int Count
+        {
+            get
+            {
+                lock (SyncRoot)
+                {
+                    return set.Count;
+                }
+            }
+        }
+
+        public bool IsReadOnly => false;
+
+        public bool Add(T item)
+        {
+            lock (SyncRoot)
+            {
+                if (set.Add(item))
+                {
+                    CollectionChanged?.Invoke(NotifyCollectionChangedEventArgs<T>.Add(item, -1));
+                    return true;
+                }
+
+                return false;
+            }
+        }
+
+        public void AddRange(IEnumerable<T> items)
+        {
+            lock (SyncRoot)
+            {
+                if (!items.TryGetNonEnumeratedCount(out var capacity))
+                {
+                    capacity = 4;
+                }
+
+                using (var list = new ResizableArray<T>(capacity))
+                {
+                    foreach (var item in items)
+                    {
+                        if (set.Add(item))
+                        {
+                            list.Add(item);
+                        }
+                    }
+
+                    CollectionChanged?.Invoke(NotifyCollectionChangedEventArgs<T>.Add(list.Span, -1));
+                }
+            }
+        }
+
+        public void AddRange(T[] items)
+        {
+            AddRange(items.AsSpan());
+        }
+
+        public void AddRange(ReadOnlySpan<T> items)
+        {
+            lock (SyncRoot)
+            {
+                using (var list = new ResizableArray<T>(items.Length))
+                {
+                    foreach (var item in items)
+                    {
+                        if (set.Add(item))
+                        {
+                            list.Add(item);
+                        }
+                    }
+
+                    CollectionChanged?.Invoke(NotifyCollectionChangedEventArgs<T>.Add(list.Span, -1));
+                }
+            }
+        }
+
+        public bool Remove(T item)
+        {
+            lock (SyncRoot)
+            {
+                if (set.Remove(item))
+                {
+                    CollectionChanged?.Invoke(NotifyCollectionChangedEventArgs<T>.Remove(item, -1));
+                    return true;
+                }
+
+                return false;
+            }
+        }
+
+        public void RemoveRange(IEnumerable<T> items)
+        {
+            lock (SyncRoot)
+            {
+                if (!items.TryGetNonEnumeratedCount(out var capacity))
+                {
+                    capacity = 4;
+                }
+
+                using (var list = new ResizableArray<T>(capacity))
+                {
+                    foreach (var item in items)
+                    {
+                        if (set.Remove(item))
+                        {
+                            list.Add(item);
+                        }
+                    }
+
+                    CollectionChanged?.Invoke(NotifyCollectionChangedEventArgs<T>.Remove(list.Span, -1));
+                }
+            }
+        }
+
+        public void RemoveRange(T[] items)
+        {
+            RemoveRange(items.AsSpan());
+        }
+
+        public void RemoveRange(ReadOnlySpan<T> items)
+        {
+            lock (SyncRoot)
+            {
+                using (var list = new ResizableArray<T>(items.Length))
+                {
+                    foreach (var item in items)
+                    {
+                        if (set.Remove(item))
+                        {
+                            list.Add(item);
+                        }
+                    }
+
+                    CollectionChanged?.Invoke(NotifyCollectionChangedEventArgs<T>.Remove(list.Span, -1));
+                }
+            }
+        }
+
+        public void Clear()
+        {
+            lock (SyncRoot)
+            {
+                set.Clear();
+                CollectionChanged?.Invoke(NotifyCollectionChangedEventArgs<T>.Reset());
+            }
+        }
+
+#if !NETSTANDARD2_0 && !NET_STANDARD_2_0 && !NET_4_6
+
+        public bool TryGetValue(T equalValue, [MaybeNullWhen(false)] out T actualValue)
+        {
+            lock (SyncRoot)
+            {
+                return set.TryGetValue(equalValue, out actualValue);
+            }
+        }
+
+#endif
+
+        public bool Contains(T item)
+        {
+            lock (SyncRoot)
+            {
+                return set.Contains(item);
+            }
+        }
+
+        public bool IsProperSubsetOf(IEnumerable<T> other)
+        {
+            lock (SyncRoot)
+            {
+                return set.IsProperSubsetOf(other);
+            }
+        }
+
+        public bool IsProperSupersetOf(IEnumerable<T> other)
+        {
+            lock (SyncRoot)
+            {
+                return set.IsProperSupersetOf(other);
+            }
+        }
+
+        public bool IsSubsetOf(IEnumerable<T> other)
+        {
+            lock (SyncRoot)
+            {
+                return set.IsSubsetOf(other);
+            }
+        }
+
+        public bool IsSupersetOf(IEnumerable<T> other)
+        {
+            lock (SyncRoot)
+            {
+                return set.IsSupersetOf(other);
+            }
+        }
+
+        public bool Overlaps(IEnumerable<T> other)
+        {
+            lock (SyncRoot)
+            {
+                return set.Overlaps(other);
+            }
+        }
+
+        public bool SetEquals(IEnumerable<T> other)
+        {
+            lock (SyncRoot)
+            {
+                return set.SetEquals(other);
+            }
+        }
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            lock (SyncRoot)
+            {
+                foreach (var item in set)
+                {
+                    yield return item;
+                }
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        public IComparer<T> Comparer
+        {
+            get
+            {
+                lock (SyncRoot)
+                {
+                    return set.Comparer;
+                }
+            }
+        }
+
+        // SortedSet-specific properties
+        public T? Min
+        {
+            get
+            {
+                lock (SyncRoot)
+                {
+                    return set.Count > 0 ? set.Min : default;
+                }
+            }
+        }
+
+        public T? Max
+        {
+            get
+            {
+                lock (SyncRoot)
+                {
+                    return set.Count > 0 ? set.Max : default;
+                }
+            }
+        }
+
+        // SortedSet-specific methods
+        public IEnumerable<T> Reverse()
+        {
+            lock (SyncRoot)
+            {
+                return set.Reverse().ToArray();
+            }
+        }
+
+        public IEnumerable<T> GetViewBetween(T lowerValue, T upperValue)
+        {
+            lock (SyncRoot)
+            {
+                return set.GetViewBetween(lowerValue, upperValue).ToArray();
+            }
+        }
+    }
+}

--- a/src/ObservableCollections/ObservableSortedSet.cs
+++ b/src/ObservableCollections/ObservableSortedSet.cs
@@ -55,7 +55,9 @@ namespace ObservableCollections
             {
                 if (set.Add(item))
                 {
-                    CollectionChanged?.Invoke(NotifyCollectionChangedEventArgs<T>.Add(item, -1));
+                    // Calculate the index where the item was inserted
+                    var index = set.TakeWhile(x => set.Comparer.Compare(x, item) < 0).Count();
+                    CollectionChanged?.Invoke(NotifyCollectionChangedEventArgs<T>.Add(item, index));
                     return true;
                 }
 
@@ -67,22 +69,14 @@ namespace ObservableCollections
         {
             lock (SyncRoot)
             {
-                if (!items.TryGetNonEnumeratedCount(out var capacity))
+                foreach (var item in items)
                 {
-                    capacity = 4;
-                }
-
-                using (var list = new ResizableArray<T>(capacity))
-                {
-                    foreach (var item in items)
+                    if (set.Add(item))
                     {
-                        if (set.Add(item))
-                        {
-                            list.Add(item);
-                        }
+                        // Calculate the index where the item was inserted
+                        var index = set.TakeWhile(x => set.Comparer.Compare(x, item) < 0).Count();
+                        CollectionChanged?.Invoke(NotifyCollectionChangedEventArgs<T>.Add(item, index));
                     }
-
-                    CollectionChanged?.Invoke(NotifyCollectionChangedEventArgs<T>.Add(list.Span, -1));
                 }
             }
         }
@@ -96,17 +90,14 @@ namespace ObservableCollections
         {
             lock (SyncRoot)
             {
-                using (var list = new ResizableArray<T>(items.Length))
+                foreach (var item in items)
                 {
-                    foreach (var item in items)
+                    if (set.Add(item))
                     {
-                        if (set.Add(item))
-                        {
-                            list.Add(item);
-                        }
+                        // Calculate the index where the item was inserted
+                        var index = set.TakeWhile(x => set.Comparer.Compare(x, item) < 0).Count();
+                        CollectionChanged?.Invoke(NotifyCollectionChangedEventArgs<T>.Add(item, index));
                     }
-
-                    CollectionChanged?.Invoke(NotifyCollectionChangedEventArgs<T>.Add(list.Span, -1));
                 }
             }
         }
@@ -115,9 +106,12 @@ namespace ObservableCollections
         {
             lock (SyncRoot)
             {
-                if (set.Remove(item))
+                if (set.Contains(item))
                 {
-                    CollectionChanged?.Invoke(NotifyCollectionChangedEventArgs<T>.Remove(item, -1));
+                    // Calculate the index before removing
+                    var index = set.TakeWhile(x => set.Comparer.Compare(x, item) < 0).Count();
+                    set.Remove(item);
+                    CollectionChanged?.Invoke(NotifyCollectionChangedEventArgs<T>.Remove(item, index));
                     return true;
                 }
 
@@ -129,22 +123,15 @@ namespace ObservableCollections
         {
             lock (SyncRoot)
             {
-                if (!items.TryGetNonEnumeratedCount(out var capacity))
+                foreach (var item in items)
                 {
-                    capacity = 4;
-                }
-
-                using (var list = new ResizableArray<T>(capacity))
-                {
-                    foreach (var item in items)
+                    if (set.Contains(item))
                     {
-                        if (set.Remove(item))
-                        {
-                            list.Add(item);
-                        }
+                        // Calculate the index before removing
+                        var index = set.TakeWhile(x => set.Comparer.Compare(x, item) < 0).Count();
+                        set.Remove(item);
+                        CollectionChanged?.Invoke(NotifyCollectionChangedEventArgs<T>.Remove(item, index));
                     }
-
-                    CollectionChanged?.Invoke(NotifyCollectionChangedEventArgs<T>.Remove(list.Span, -1));
                 }
             }
         }
@@ -158,17 +145,15 @@ namespace ObservableCollections
         {
             lock (SyncRoot)
             {
-                using (var list = new ResizableArray<T>(items.Length))
+                foreach (var item in items)
                 {
-                    foreach (var item in items)
+                    if (set.Contains(item))
                     {
-                        if (set.Remove(item))
-                        {
-                            list.Add(item);
-                        }
+                        // Calculate the index before removing
+                        var index = set.TakeWhile(x => set.Comparer.Compare(x, item) < 0).Count();
+                        set.Remove(item);
+                        CollectionChanged?.Invoke(NotifyCollectionChangedEventArgs<T>.Remove(item, index));
                     }
-
-                    CollectionChanged?.Invoke(NotifyCollectionChangedEventArgs<T>.Remove(list.Span, -1));
                 }
             }
         }

--- a/tests/ObservableCollections.Tests/ObservableCollections.Tests.csproj
+++ b/tests/ObservableCollections.Tests/ObservableCollections.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/ObservableCollections.Tests/ObservableSortedSetTest.cs
+++ b/tests/ObservableCollections.Tests/ObservableSortedSetTest.cs
@@ -1,0 +1,110 @@
+using FluentAssertions;
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace ObservableCollections.Tests
+{
+    public class ObservableSortedSetTest
+    {
+        [Fact]
+        public void View()
+        {
+            var set = new ObservableSortedSet<int>();
+            var view = set.CreateView(x => new ViewContainer<int>(x));
+
+            set.Add(10);
+            set.Add(50);
+            set.Add(30);
+            set.Add(20);
+            set.Add(40);
+
+            void Equal(params int[] expected)
+            {
+                set.Should().BeEquivalentTo(expected);
+                view.Select(x => x.Value).Should().BeEquivalentTo(expected);
+            }
+
+            Equal(10, 50, 30, 20, 40);
+
+            set.AddRange(new[] { 1, 2, 3, 4, 5 });
+            Equal(10, 50, 30, 20, 40, 1, 2, 3, 4, 5);
+
+            set.Remove(10);
+            Equal(50, 30, 20, 40, 1, 2, 3, 4, 5);
+
+            set.RemoveRange(new[] { 50, 40 });
+            Equal(30, 20, 1, 2, 3, 4, 5);
+
+            set.Clear();
+
+            Equal();
+        }
+
+        [Fact]
+        public void SortedOrder()
+        {
+            var set = new ObservableSortedSet<int>();
+
+            set.Add(50);
+            set.Add(10);
+            set.Add(30);
+            set.Add(20);
+            set.Add(40);
+
+            // SortedSet maintains sorted order
+            set.Should().ContainInOrder(10, 20, 30, 40, 50);
+        }
+
+        [Fact]
+        public void MinMax()
+        {
+            var set = new ObservableSortedSet<int>();
+
+            set.Add(50);
+            set.Add(10);
+            set.Add(30);
+            set.Add(20);
+            set.Add(40);
+
+            set.Min.Should().Be(10);
+            set.Max.Should().Be(50);
+        }
+
+        [Fact]
+        public void CustomComparer()
+        {
+            // Descending order comparer
+            var set = new ObservableSortedSet<int>(Comparer<int>.Create((x, y) => y.CompareTo(x)));
+
+            set.Add(50);
+            set.Add(10);
+            set.Add(30);
+            set.Add(20);
+            set.Add(40);
+
+            // Should be in descending order
+            set.Should().ContainInOrder(50, 40, 30, 20, 10);
+        }
+
+        [Fact]
+        public void IndexOutOfRange()
+        {
+            // https://github.com/Cysharp/ObservableCollections/pull/51
+            static IEnumerable<int> Range(int count)
+            {
+                foreach (var i in Enumerable.Range(0, count))
+                {
+                    yield return i;
+                }
+            }
+
+            var set = new ObservableSortedSet<int>();
+            set.AddRange(Range(20));
+        }
+    }
+}


### PR DESCRIPTION
Full disclaimer, this is courtesy of Copilot Agent, but it seems to work okay :) I think it would be a helpful addition to the library!

Copilot's description:

### Changes

**Core Implementation** (`ObservableSortedSet.cs`)
- Wraps `SortedSet<T>` with thread-safe operations and change notifications
- Implements `IReadOnlySet<T>` and `IObservableCollection<T>`
- Exposes SortedSet-specific API: `Min`, `Max`, `Comparer`, `Reverse()`, `GetViewBetween()`
- Supports range operations: `AddRange()`, `RemoveRange()`

**View Support** (`ObservableSortedSet.Views.cs`)
- Implements synchronized views with filtering and transformation
- Compatible with `ToNotifyCollectionChanged()` for XAML binding

**Documentation**
- Updated README to include `ObservableSortedSet<T>` in collection list
