### PR TITLE
fix: ObserveCountChanged misses count if observer has side effect

### DIFF
--- a/src/ObservableCollections.R3/ObservableCollectionR3Extensions.cs
+++ b/src/ObservableCollections.R3/ObservableCollectionR3Extensions.cs
@@ -438,10 +438,10 @@ sealed class ObservableCollectionCountChanged<T>(IObservableCollection<T> collec
                 case NotifyCollectionChangedAction.Add:
                 case NotifyCollectionChangedAction.Remove:
                 case NotifyCollectionChangedAction.Reset when countPrev != collection.Count:
+                    countPrev = collection.Count;
                     observer.OnNext(collection.Count);
                     break;
             }
-            countPrev = collection.Count;
         }
     }
 }

--- a/tests/ObservableCollections.R3.Tests/ObservableCollectionExtensionsTest.cs
+++ b/tests/ObservableCollections.R3.Tests/ObservableCollectionExtensionsTest.cs
@@ -161,7 +161,7 @@ public class ObservableCollectionExtensionsTest
         collection[1] = 444;
         events.Count.Should().Be(1);
     }
-    
+
     [Fact]
     public void ObserveDictionaryReplace()
     {
@@ -245,6 +245,27 @@ public class ObservableCollectionExtensionsTest
 
         collection.Clear();
         events.Count.Should().Be(3);
+    }
+
+    [Fact]
+    public void ObserveCountChanged_WithSideEffect()
+    {
+        var events = new List<int>();
+        var collection = new ObservableList<int>([]);
+
+        using var _ = collection.ObserveCountChanged().Subscribe(count =>
+        {
+            events.Add(count);
+            // Side effect - when count is 1, clear the list
+            if(count == 1) collection.Clear();
+        });
+
+        events.Should().BeEmpty();
+
+        collection.Add(12);
+
+        collection.Count.Should().Be(0);
+        events.Should().BeEquivalentTo([1, 0]);
     }
 
     [Fact]


### PR DESCRIPTION
The issue is that OnNext can have any number of side effects. If a side effect modifies the collection.Count, then the countPrev will be inaccurate, because the collection.Count has changed. It was not the same value that was actually emitted.

```
        protected override void Handler(in NotifyCollectionChangedEventArgs<T> eventArgs)
        {
            switch (eventArgs.Action)
            {
                case NotifyCollectionChangedAction.Add:
                case NotifyCollectionChangedAction.Remove:
                case NotifyCollectionChangedAction.Reset when countPrev != collection.Count:
                    observer.OnNext(collection.Count);
                    break;
            }
            countPrev = collection.Count; // Issue: collection.Count be a different value from the emitted value above, if OnNext has side effects.
        }
```

To fix this, I moved the countPrev assignment to before the emission. That way it is guaranteed that countPrev matches the value that we actually emitted.