### PR TITLE
Implement CopyTo on synchronized view lists

### DIFF
--- a/src/ObservableCollections/IObservableCollection.cs
+++ b/src/ObservableCollections/IObservableCollection.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
@@ -124,8 +124,24 @@ namespace ObservableCollections
         public abstract bool Remove(TView item);
         public abstract void RemoveAt(int index);
         public abstract void Clear();
-
         public abstract bool Contains(TView item);
+
+        public virtual void CopyTo(Span<TView> span)
+        {
+            lock (gate)
+            {
+                var count = Count;
+                if (span.Length < count)
+                {
+                    throw new ArgumentException("Destination is too short.", nameof(span));
+                }
+
+                for (var i = 0; i < count; ++i)
+                {
+                    span[i] = this[i];
+                }
+            }
+        }
 
         bool IList.Contains(object? value)
         {
@@ -163,13 +179,69 @@ namespace ObservableCollections
         {
             Clear();
         }
+
         void IList.Clear()
         {
             Clear();
         }
 
-        void ICollection<TView>.CopyTo(TView[] array, int arrayIndex) => throw new NotSupportedException();
-        void ICollection.CopyTo(Array array, int index) => throw new NotSupportedException();
+        void ICollection<TView>.CopyTo(TView[] array, int arrayIndex)
+        {
+            if (array is null)
+            {
+                throw new ArgumentNullException(nameof(array));
+            }
+
+            CopyTo(array.AsSpan(arrayIndex));
+        }
+
+        void ICollection.CopyTo(Array array, int arrayIndex)
+        {
+            if (array is null)
+            {
+                throw new ArgumentNullException(nameof(array));
+            }
+
+            if (arrayIndex < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(arrayIndex));
+            }
+
+            if (array.Rank != 1)
+            {
+                throw new ArgumentException("Only single dimensional arrays are supported.", nameof(array));
+            }
+
+            if (array.GetLowerBound(0) != 0)
+            {
+                throw new ArgumentException("The lower bound of target array must be zero.", nameof(array));
+            }
+
+            if (array is TView[] typedArray)
+            {
+                CopyTo(typedArray.AsSpan(arrayIndex));
+            }
+            else
+            {
+                var index = arrayIndex;
+
+                foreach (var item in this)
+                {
+                    try
+                    {
+                        array.SetValue(item, index++);
+                    }
+                    catch (IndexOutOfRangeException e)
+                    {
+                        throw new ArgumentException("Destination is too short.", nameof(array), e);
+                    }
+                    catch (InvalidCastException e)
+                    {
+                        throw new ArgumentException("Object cannot be stored in an array of this type.", nameof(array), e);
+                    }
+                }
+            }
+        }
 
         void IList<TView>.Insert(int index, TView item)
         {

--- a/src/ObservableCollections/ObservableDictionary.Views.cs
+++ b/src/ObservableCollections/ObservableDictionary.Views.cs
@@ -1,5 +1,4 @@
-﻿using ObservableCollections.Internal;
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;

--- a/src/ObservableCollections/ObservableList.OptimizeView.cs
+++ b/src/ObservableCollections/ObservableList.OptimizeView.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
-using System.Text;
 
 namespace ObservableCollections;
 
@@ -217,5 +215,11 @@ internal sealed class ObservableListSynchronizedViewList<T> : NotifyCollectionCh
     public override int IndexOf(T item)
     {
         return parent.IndexOf(item);
+    }
+
+    /// <inheritdoc />
+    public override void CopyTo(Span<T> span)
+    {
+        parent.CopyTo(span);
     }
 }

--- a/src/ObservableCollections/ObservableList.cs
+++ b/src/ObservableCollections/ObservableList.cs
@@ -134,9 +134,21 @@ namespace ObservableCollections
 
         public void CopyTo(T[] array, int arrayIndex)
         {
+            if (array is null)
+            {
+                throw new ArgumentNullException(nameof(array));
+            }
+
+            CopyTo(array.AsSpan(arrayIndex));
+        }
+
+        public void CopyTo(Span<T> span)
+        {
             lock (SyncRoot)
             {
-                list.CopyTo(array, arrayIndex);
+#pragma warning disable CS0436
+                CollectionsMarshal.AsSpan(list).CopyTo(span);
+#pragma warning restore
             }
         }
 

--- a/src/ObservableCollections/SynchronizedViewList.cs
+++ b/src/ObservableCollections/SynchronizedViewList.cs
@@ -1,4 +1,4 @@
-using ObservableCollections.Internal;
+﻿using ObservableCollections.Internal;
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
@@ -508,6 +508,26 @@ internal sealed class FiltableSynchronizedViewList<T, TView> : NotifyCollectionC
         return -1;
     }
 
+    /// <inheritdoc />
+    public override void CopyTo(Span<TView> span)
+    {
+        lock (gate)
+        {
+            var local = listView;
+            var sourceLength = local.Count;
+
+            if (span.Length < sourceLength)
+            {
+                throw new ArgumentException("Destination is too short.", nameof(span));
+            }
+
+            for (var i = 0; i < sourceLength; ++i)
+            {
+                span[i] = local[i];
+            }
+        }
+    }
+
     public override void Dispose()
     {
         parent.ViewChanged -= Parent_ViewChanged;
@@ -1007,6 +1027,17 @@ internal sealed class NonFilteredSynchronizedViewList<T, TView> : NotifyCollecti
             }
         }
         return -1;
+    }
+
+    /// <inheritdoc />
+    public override void CopyTo(Span<TView> span)
+    {
+        lock (gate)
+        {
+#pragma warning disable CS0436
+            CollectionsMarshal.AsSpan(listView).CopyTo(span);
+#pragma warning restore
+        }
     }
 
     public override void Dispose()

--- a/tests/ObservableCollections.Tests/CopyToTest.cs
+++ b/tests/ObservableCollections.Tests/CopyToTest.cs
@@ -1,0 +1,350 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ObservableCollections.Tests;
+
+public class ObservableListCopyToTest
+{
+    static ObservableList<int> CreateSource()
+    {
+        return new ObservableList<int> { 1, 2, 3 };
+    }
+
+    /// <summary>
+    /// Ensures all items are copied from the beginning of the array.
+    /// </summary>
+    [Fact]
+    public void CopyToArray()
+    {
+        var destination = new int[3];
+
+        CreateSource().CopyTo(destination, 0);
+
+        destination.Should().Equal(1, 2, 3);
+    }
+
+    /// <summary>
+    /// Ensures items are copied from the position specified by arrayIndex, leaving the preceding elements untouched.
+    /// </summary>
+    [Fact]
+    public void CopyToArrayWithOffset()
+    {
+        var destination = new int[5];
+
+        CreateSource().CopyTo(destination, 2);
+
+        destination.Should().Equal(0, 0, 1, 2, 3);
+    }
+
+    /// <summary>
+    /// Ensures all items are copied through the Span overload.
+    /// </summary>
+    [Fact]
+    public void CopyToSpan()
+    {
+        var destination = new int[3];
+
+        CreateSource().CopyTo(destination.AsSpan());
+
+        destination.Should().Equal(1, 2, 3);
+    }
+
+    /// <summary>
+    /// Ensures the remaining space is left untouched when the destination is longer than the item count.
+    /// </summary>
+    [Fact]
+    public void CopyToLongerDestination()
+    {
+        var destination = new[] { -1, -1, -1, -1, -1 };
+
+        CreateSource().CopyTo(destination.AsSpan());
+
+        destination.Should().Equal(1, 2, 3, -1, -1);
+    }
+
+    /// <summary>
+    /// Ensures an empty collection copies nothing and does not throw.
+    /// </summary>
+    [Fact]
+    public void CopyToFromEmpty()
+    {
+        var destination = new[] { -1 };
+
+        new ObservableList<int>().CopyTo(destination, 0);
+
+        destination.Should().Equal(-1);
+    }
+
+    /// <summary>
+    /// Ensures ArgumentException is thrown when the space after arrayIndex is not enough for the item count.
+    /// </summary>
+    [Fact]
+    public void TooShortDestinationThrows()
+    {
+        var source = CreateSource();
+
+        Action tooShortArray = () => source.CopyTo(new int[2], 0);
+        Action tooShortByOffset = () => source.CopyTo(new int[3], 1);
+        Action tooShortSpan = () => source.CopyTo(new int[2].AsSpan());
+
+        tooShortArray.Should().ThrowExactly<ArgumentException>();
+        tooShortByOffset.Should().ThrowExactly<ArgumentException>();
+        tooShortSpan.Should().ThrowExactly<ArgumentException>();
+    }
+
+    /// <summary>
+    /// Ensures ArgumentNullException is thrown when array is null, whether or not the collection has items.
+    /// </summary>
+    [Fact]
+    public void NullArrayThrows()
+    {
+        Action nonEmpty = () => CreateSource().CopyTo(null!, 0);
+        Action empty = () => new ObservableList<int>().CopyTo(null!, 0);
+
+        nonEmpty.Should().ThrowExactly<ArgumentNullException>();
+        empty.Should().ThrowExactly<ArgumentNullException>();
+    }
+
+    /// <summary>
+    /// Ensures ArgumentOutOfRangeException is thrown when arrayIndex is negative.
+    /// </summary>
+    [Fact]
+    public void NegativeArrayIndexThrows()
+    {
+        Action act = () => CreateSource().CopyTo(new int[3], -1);
+
+        act.Should().ThrowExactly<ArgumentOutOfRangeException>();
+    }
+}
+
+/// <summary>
+/// Verifies that CopyTo behaves consistently across every derived implementation of NotifyCollectionChangedSynchronizedViewList.
+/// </summary>
+public abstract class SynchronizedViewListCopyToTestBase
+{
+    protected abstract NotifyCollectionChangedSynchronizedViewList<int> CreateViewList(ObservableList<int> source);
+
+    private NotifyCollectionChangedSynchronizedViewList<int> CreateViewList()
+    {
+        return CreateViewList(new ObservableList<int> { 1, 2, 3 });
+    }
+
+    /// <summary>
+    /// Ensures ICollection&lt;T&gt;.CopyTo copies all items from the beginning of the array.
+    /// </summary>
+    [Fact]
+    public void CopyToArray()
+    {
+        var destination = new int[3];
+
+        ((ICollection<int>)CreateViewList()).CopyTo(destination, 0);
+
+        destination.Should().Equal(1, 2, 3);
+    }
+
+    /// <summary>
+    /// Ensures items are copied from the position specified by arrayIndex, leaving the preceding elements untouched.
+    /// </summary>
+    [Fact]
+    public void CopyToArrayWithOffset()
+    {
+        var destination = new int[5];
+
+        ((ICollection<int>)CreateViewList()).CopyTo(destination, 2);
+
+        destination.Should().Equal(0, 0, 1, 2, 3);
+    }
+
+    /// <summary>
+    /// Ensures all items are copied through the Span overload.
+    /// </summary>
+    [Fact]
+    public void CopyToSpan()
+    {
+        var destination = new int[3];
+
+        CreateViewList().CopyTo(destination.AsSpan());
+
+        destination.Should().Equal(1, 2, 3);
+    }
+
+    /// <summary>
+    /// Ensures ToList returns a List that preserves every item and its order.
+    /// </summary>
+    [Fact]
+    public void ToList()
+    {
+        CreateViewList().ToList().Should().Equal(1, 2, 3);
+    }
+
+    /// <summary>
+    /// Ensures the non-generic ICollection.CopyTo works against an array of the item type itself.
+    /// </summary>
+    [Fact]
+    public void CopyToNonGenericTypedArray()
+    {
+        var destination = new int[3];
+
+        ((ICollection)CreateViewList()).CopyTo(destination, 0);
+
+        destination.Should().Equal(1, 2, 3);
+    }
+
+    /// <summary>
+    /// Ensures the non-generic ICollection.CopyTo also works against object[],
+    /// which is what non-generic callers such as WPF pass in.
+    /// </summary>
+    [Fact]
+    public void CopyToObjectArray()
+    {
+        var destination = new object[3];
+
+        ((ICollection)CreateViewList()).CopyTo(destination, 0);
+
+        destination.Should().Equal(1, 2, 3);
+    }
+
+    /// <summary>
+    /// Ensures an empty collection copies nothing and does not throw.
+    /// </summary>
+    [Fact]
+    public void CopyToFromEmpty()
+    {
+        var destination = new[] { -1 };
+
+        ((ICollection<int>)CreateViewList(new ObservableList<int>())).CopyTo(destination, 0);
+
+        destination.Should().Equal(-1);
+    }
+
+    /// <summary>
+    /// Ensures ArgumentException is thrown regardless of the implementation when the space after arrayIndex is not enough for the item count.
+    /// </summary>
+    [Fact]
+    public void TooShortDestinationThrows()
+    {
+        var list = CreateViewList();
+
+        Action tooShortArray = () => ((ICollection<int>)list).CopyTo(new int[2], 0);
+        Action tooShortByOffset = () => ((ICollection<int>)list).CopyTo(new int[3], 1);
+        Action tooShortSpan = () => list.CopyTo(new int[2].AsSpan());
+
+        tooShortArray.Should().ThrowExactly<ArgumentException>();
+        tooShortByOffset.Should().ThrowExactly<ArgumentException>();
+        tooShortSpan.Should().ThrowExactly<ArgumentException>();
+    }
+
+    /// <summary>
+    /// Ensures ArgumentNullException is thrown when array is null, whether or not the collection has items.
+    /// </summary>
+    [Fact]
+    public void NullArrayThrows()
+    {
+        Action nonEmpty = () => ((ICollection<int>)CreateViewList()).CopyTo(null!, 0);
+        Action empty = () => ((ICollection<int>)CreateViewList(new ObservableList<int>())).CopyTo(null!, 0);
+
+        nonEmpty.Should().ThrowExactly<ArgumentNullException>();
+        empty.Should().ThrowExactly<ArgumentNullException>();
+    }
+
+    /// <summary>
+    /// Ensures ArgumentOutOfRangeException is thrown when arrayIndex is negative.
+    /// </summary>
+    [Fact]
+    public void NegativeArrayIndexThrows()
+    {
+        Action act = () => ((ICollection<int>)CreateViewList()).CopyTo(new int[3], -1);
+
+        act.Should().ThrowExactly<ArgumentOutOfRangeException>();
+    }
+}
+
+public class ObservableListSynchronizedViewListCopyToTest : SynchronizedViewListCopyToTestBase
+{
+    protected override NotifyCollectionChangedSynchronizedViewList<int> CreateViewList(ObservableList<int> source)
+    {
+        return source.ToNotifyCollectionChangedSlim();
+    }
+}
+
+public sealed class NonFilteredSynchronizedViewListCopyToTest : SynchronizedViewListCopyToTestBase
+{
+    protected override NotifyCollectionChangedSynchronizedViewList<int> CreateViewList(ObservableList<int> source)
+    {
+        return source.ToNotifyCollectionChanged();
+    }
+}
+
+public sealed class FiltableSynchronizedViewListCopyToTest : SynchronizedViewListCopyToTestBase
+{
+    protected override NotifyCollectionChangedSynchronizedViewList<int> CreateViewList(ObservableList<int> source)
+    {
+        return source.CreateView(static x => x).ToNotifyCollectionChanged();
+    }
+
+    /// <summary>
+    /// Ensures Count and the copied result contain only the filtered items when the filter is attached before the view list is created.
+    /// </summary>
+    [Fact]
+    public void CopyToWithFilterAttachedBeforeCreate()
+    {
+        var view = new ObservableList<int> { 1, 2, 3, 4, 5 }.CreateView(static x => x);
+        view.AttachFilter(static x => x % 2 == 1);
+
+        var list = view.ToNotifyCollectionChanged();
+
+        list.Count.Should().Be(3);
+        list.ToList().Should().Equal(1, 3, 5);
+    }
+
+    /// <summary>
+    /// Ensures Count and the copied result contain only the filtered items when the filter is attached after the view list is created.
+    /// </summary>
+    [Fact]
+    public void CopyToWithFilterAttachedAfterCreate()
+    {
+        var view = new ObservableList<int> { 1, 2, 3, 4, 5 }.CreateView(static x => x);
+        var list = view.ToNotifyCollectionChanged();
+
+        view.AttachFilter(static x => x % 2 == 1);
+
+        list.Count.Should().Be(3);
+        list.ToList().Should().Equal(1, 3, 5);
+    }
+
+    /// <summary>
+    /// Ensures all items are copied again after ResetFilter.
+    /// </summary>
+    [Fact]
+    public void CopyToAfterResetFilter()
+    {
+        var view = new ObservableList<int> { 1, 2, 3, 4, 5 }.CreateView(static x => x);
+        var list = view.ToNotifyCollectionChanged();
+
+        view.AttachFilter(static x => x % 2 == 1);
+        view.ResetFilter();
+
+        list.Count.Should().Be(5);
+        list.ToList().Should().Equal(1, 2, 3, 4, 5);
+    }
+
+    /// <summary>
+    /// Ensures the copied result contains only the filtered items even when items are added while a filter excludes some of them.
+    /// </summary>
+    [Fact]
+    public void CopyToAfterAddWithFilter()
+    {
+        var source = new ObservableList<int> { 1, 2, 3 };
+        var view = source.CreateView(static x => x);
+        var list = view.ToNotifyCollectionChanged();
+
+        view.AttachFilter(static x => x % 2 == 1);
+        source.Add(4);
+        source.Add(5);
+
+        list.Count.Should().Be(3);
+        list.ToList().Should().Equal(1, 3, 5);
+    }
+}


### PR DESCRIPTION
## Fix ICollection.CopyTo on synchronized view lists (fixes #116)

`NotifyCollectionChangedSynchronizedViewList<TView>` threw `NotSupportedException` from both `CopyTo` implementations.
`Enumerable.ToList()` takes the `ICollection<T>` fast path, so `ToViewList().ToList()` always threw on non-empty lists.

Adds `public virtual void CopyTo(Span<TView> span)`, overridden by the three derived types, and implements both interface methods on top of it with the documented argument validation. `ObservableList<T>` gains `CopyTo(Span<T>)`.